### PR TITLE
Add build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build & test
-      run: |
-        chmod +x ./build.sh               # ensure it is executable
-        ./build.sh
+      run: bash ./build.sh
         
   linux-gcc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Build & test
-      run: |
-        chmod +x ./build.sh
-        ./build.sh
+      run: bash ./build.sh

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,20 @@
+@ECHO OFF
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+CD /D "%~dp0"
+
+PUSHD PikaCmd\SourceDistribution
+SET CPP_TARGET=beta
+DEL /Q PikaCmd.exe 2>NUL
+CALL BuildPikaCmd.cmd
+IF ERRORLEVEL 1 GOTO error
+
+DEL /Q PikaCmd.exe 2>NUL
+SET CPP_TARGET=release
+CALL BuildPikaCmd.cmd
+IF ERRORLEVEL 1 GOTO error
+
+POPD
+
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
+
+(cd PikaCmd/SourceDistribution && rm -f PikaCmd && CPP_TARGET=beta bash BuildPikaCmd.sh)
+
+(cd PikaCmd/SourceDistribution && rm -f PikaCmd && CPP_TARGET=release bash BuildPikaCmd.sh)


### PR DESCRIPTION
## Summary
- add root build scripts for portability
- update CI to call the root build scripts

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68778aff63688332bac808278ca591f3