### PR TITLE
Fix script portability

### DIFF
--- a/PikaCmd/DownloadAndInstallPika.sh
+++ b/PikaCmd/DownloadAndInstallPika.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-
-set -e
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 if [ -z "${TMPDIR}" ]; then
 	TMPDIR="/tmp/"

--- a/PikaCmd/SourceDistribution/BuildPikaCmd.sh
+++ b/PikaCmd/SourceDistribution/BuildPikaCmd.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 if [ -e ./PikaCmd ]; then
 	chmod +x ./PikaCmd >/dev/null 2>&1

--- a/PikaCmd/SourceDistribution/InstallPika.sh
+++ b/PikaCmd/SourceDistribution/InstallPika.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-
-set -e -u
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 chmod +x ./pika
 if [ ! -d /usr/local ]; then

--- a/PikaCmd/SourceDistribution/UninstallPika.sh
+++ b/PikaCmd/SourceDistribution/UninstallPika.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 sudo rm /usr/local/bin/PikaCmd
 sudo rm /usr/local/bin/pika

--- a/PikaCmd/UpdateSourceDistribution.sh
+++ b/PikaCmd/UpdateSourceDistribution.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-
-cd "${0%/*}"
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 chmod +x ./BuildPikaCmd.sh >/dev/null 2>&1
 


### PR DESCRIPTION
## Summary
- update script headers to be portable and enable strict mode
- change scripts to cd to their own directory

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68779df3af8c8332b284e349087e9be6