### PR TITLE
Fix script portability

### DIFF
--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 if [ -z "${TMPDIR}" ]; then
 	TMPDIR="/tmp/"

--- a/tools/PikaCmd/SourceDistribution/InstallPika.sh
+++ b/tools/PikaCmd/SourceDistribution/InstallPika.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-
-set -e -u
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 chmod +x ./pika
 if [ ! -d /usr/local ]; then

--- a/tools/PikaCmd/SourceDistribution/UninstallPika.sh
+++ b/tools/PikaCmd/SourceDistribution/UninstallPika.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
 
 sudo rm /usr/local/bin/PikaCmd
 sudo rm /usr/local/bin/pika


### PR DESCRIPTION
## Summary
- patch shell scripts to conform to repository portability rules
- ensure scripts change directory before running

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877a5be8c5883328aef0ad932fc2099