### PR TITLE
Fix UpdateSourceDistribution.cmd path handling

### DIFF
--- a/tools/PikaCmd/UpdateSourceDistribution.cmd
+++ b/tools/PikaCmd/UpdateSourceDistribution.cmd
@@ -1,5 +1,6 @@
 @ECHO OFF
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+CD /D "%~dp0"
 
 IF NOT EXIST PikaCmd.exe (
 	CALL BuildCpp PikaCmd.exe -DPLATFORM_STRING=WINDOWS PikaCmd.cpp BuiltIns.cpp ..\src\*.cpp


### PR DESCRIPTION
## Summary
- ensure `UpdateSourceDistribution.cmd` changes to its own directory before running

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877e33c06fc83329f3bf987c5fdff2b