### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  push:
+    tags: [ '*']
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create.outputs.upload_url }}
+    steps:
+    - name: Create release
+      id: create
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: ${{ github.ref_name }}
+        draft: false
+        prerelease: false
+
+  linux:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: bash ./build.sh
+    - name: Package SourceDistribution
+      run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ./PikaCmdSourceDistribution.tar.gz
+        asset_name: PikaCmdSourceDistribution.tar.gz
+        asset_content_type: application/gzip
+
+  macos:
+    needs: create_release
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: bash ./build.sh
+    - name: Package SourceDistribution
+      run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
+
+  windows:
+    needs: create_release
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Build
+      run: .\build.cmd
+    - name: Package SourceDistribution
+      shell: pwsh
+      run: Compress-Archive -Path tools/PikaCmd/SourceDistribution/* -DestinationPath PikaCmdSourceDistribution.zip
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ./PikaCmdSourceDistribution.zip
+        asset_name: PikaCmdSourceDistribution.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
## Summary
- create release pipeline triggered by tag pushes
- build PikaCmd on Windows, macOS and Linux
- package `tools/PikaCmd/SourceDistribution` and upload to a GitHub release

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6878193e55cc8332bb987f38d8302788