### PR TITLE
Make PPEG library work from any folder

### DIFF
--- a/examples/parsing.pika
+++ b/examples/parsing.pika
@@ -1,4 +1,7 @@
-SOURCE_ROOT = coalesce(@::SOURCE_ROOT, @::run.root, 'examples/');
+include('systools.pika');
+include('stdlib.pika');
+ROOT = coalesce(@::ROOT, run.root # '../');
+SOURCE_ROOT = coalesce(@::SOURCE_ROOT, run.root, 'examples/');
 include(SOURCE_ROOT # 'objects.pika');
 
 PIKA_COMMENTS['/*'] = '*/';
@@ -812,17 +815,7 @@ runPeg = function {
 	}
 };
 
-run(SOURCE_ROOT # 'initPPEG.pika');
-
-PPEG = function {
-	this = this();
-	[this].source = $0;
-	[this].parse = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.parse(@[this()].grammar, source, dd, rule) };
-	// FIX : how to restore the previous trace (might be traceErrors for example)
-	[this].trace = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.trace(g = @[this()].grammar); ppeg.parse(g, source, dd, rule); trace() };
-	[this].clone = function { construct($0, PPEG, [this()].source) };
-	ppeg.compile(@[this].grammar, [this].source)
-};
+include(ROOT # 'tools/ppeg/ppeg.pika');
 
 TreePPEG = function {
 	this = this();

--- a/tests/ppegTest.pika
+++ b/tests/ppegTest.pika
@@ -1,16 +1,9 @@
+include('systools.pika');
 include('stdlib.pika');
-run('tools/ppeg/initPPEG.pika');
+include(run.root # '../tools/ppeg/ppeg.pika');
 
-PPEG = function {
-        this = this();
-        [this].source = $0;
-        [this].parse = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.parse(@[this()].grammar, source, dd, rule) };
-        [this].trace = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.trace(g = @[this()].grammar); ppeg.parse(g, source, dd, rule); trace() };
-        [this].clone = function { construct($0, PPEG, [this()].source) };
-        ppeg.compile(@[this].grammar, [this].source)
-};
-
-digitsFile = 'examples/digits.ppeg';
+SOURCE_ROOT = run.root # '../examples/';
+digitsFile = SOURCE_ROOT # 'digits.ppeg';
 
 testDigits = function {
         success = ppeg.compileFunction(src=load(digitsFile), @parseDigits);
@@ -22,7 +15,7 @@ testDigits = function {
 testDigits();
 
 // self-compile the PPEG compiler
-oldSource = newSource = load('examples/ppegGlobal.ppeg');
+oldSource = newSource = load(SOURCE_ROOT # 'ppegGlobal.ppeg');
 construct(@test1, PPEG, oldSource);
 test1.grammar.$compileTo = @test2;
 test1.parse(newSource);
@@ -32,7 +25,7 @@ ppeg.parse(@test2, newSource);
 delete(@::ppeg.$compileTo);
 delete(@::ppeg.$target);
 
-localSource = load('examples/ppegLocal.ppeg');
+localSource = load(SOURCE_ROOT # 'ppegLocal.ppeg');
 construct(@test1, PPEG, localSource);
 test1.grammar.$compileTo = @test2;
 newParser = test1.parse(localSource);

--- a/tools/ppeg/ppeg.pika
+++ b/tools/ppeg/ppeg.pika
@@ -1,0 +1,12 @@
+include('systools.pika');
+include('stdlib.pika');
+include('initPPEG.pika');
+
+PPEG = function {
+        this = this();
+        [this].source = $0;
+        [this].parse = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.parse(@[this()].grammar, source, dd, rule) };
+        [this].trace = function { vargs(@source, , @dd, @rule); defaults(@dd, @o, @rule, 'root'); ppeg.trace(g = @[this()].grammar); ppeg.parse(g, source, dd, rule); trace() };
+        [this].clone = function { construct($0, PPEG, [this()].source) };
+        ppeg.compile(@[this].grammar, [this].source)
+};

--- a/tools/ppeg/updatePPEG.pika
+++ b/tools/ppeg/updatePPEG.pika
@@ -1,7 +1,8 @@
+include('systools.pika');
 include('stdlib.pika');
-run('tools/ppeg/initPPEG.pika');
+include('ppeg.pika');
 
-SRC_ROOT = 'examples/';
+SRC_ROOT = run.root # '../../examples/';
 
 oldSource = newSource = load(SRC_ROOT # 'ppegGlobal.ppeg');
 construct(@test1, PPEG, oldSource);
@@ -28,6 +29,6 @@ if (regened !== newParser) throw('Regenerated parser is not identical');
 print('Successfully compiled itself twice (can regenerate)');
 ::ppeg.compileFunction = regened;
 
-save('tools/ppeg/initPPEG.pika', sourceFor(@::ppeg));
+save(run.root # 'initPPEG.pika', sourceFor(@::ppeg));
 print('initPPEG.pika replaced');
 


### PR DESCRIPTION
## Summary
- create `ROOT` based on `run.root` so examples can locate tools
- update `updatePPEG.pika` to write its generated file relative to the script

## Testing
- `timeout 180 ./build.sh`
- `bash tools/PikaCmd/SourceDistribution/pika tests/ppegTest.pika`
- `bash tools/PikaCmd/SourceDistribution/pika tools/ppeg/updatePPEG.pika`


------
https://chatgpt.com/codex/tasks/task_e_6878ea5e3d048332a352652f976b15e4