### PR TITLE
Ensure PPEG doc example works anywhere

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,6 +11,9 @@ POPD
 tools\PikaCmd\SourceDistribution\PikaCmd tests\ppegTest.pika
 IF ERRORLEVEL 1 GOTO error
 
+tools\PikaCmd\SourceDistribution\PikaCmd examples\ppegDocExample.pika
+IF ERRORLEVEL 1 GOTO error
+
 PUSHD tools\PikaCmd\SourceDistribution
 DEL /Q PikaCmd.exe 2>NUL
 SET CPP_TARGET=release
@@ -18,6 +21,9 @@ CALL BuildPikaCmd.cmd
 IF ERRORLEVEL 1 GOTO error
 POPD
 tools\PikaCmd\SourceDistribution\PikaCmd tests\ppegTest.pika
+IF ERRORLEVEL 1 GOTO error
+
+tools\PikaCmd\SourceDistribution\PikaCmd examples\ppegDocExample.pika
 IF ERRORLEVEL 1 GOTO error
 
 EXIT /b 0

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,8 @@ cd "$(dirname "$0")"
 
 (cd tools/PikaCmd/SourceDistribution && rm -f PikaCmd && CPP_TARGET=beta bash BuildPikaCmd.sh)
 tools/PikaCmd/SourceDistribution/PikaCmd tests/ppegTest.pika
+tools/PikaCmd/SourceDistribution/PikaCmd examples/ppegDocExample.pika
 
 (cd tools/PikaCmd/SourceDistribution && rm -f PikaCmd && CPP_TARGET=release bash BuildPikaCmd.sh)
 tools/PikaCmd/SourceDistribution/PikaCmd tests/ppegTest.pika
+tools/PikaCmd/SourceDistribution/PikaCmd examples/ppegDocExample.pika

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -50,12 +50,15 @@ new implementation to `initPPEG.pika` if everything succeeds.
 Example: Using the Local Compiler
 =================================
 
- Below is a minimal example that compiles `examples/digits.ppeg` into a local parsing function and runs it:
+ Below is a minimal example that compiles `examples/digits.ppeg` into a local parsing function and runs it.
+ The script locates both `ppeg.pika` and `digits.ppeg` relative to its own path so it works no matter
+ which directory it is launched from:
 
+    include('systools.pika');
     include('stdlib.pika');
-    include('ppeg.pika');
+    include(run.root # '../tools/ppeg/ppeg.pika');
 
-    src = load('examples/digits.ppeg');
+    src = load(run.root # 'digits.ppeg');
     parseDigits = ppeg.compileFunction(src);
 
     assert(> parseDigits('12345'));

--- a/examples/ppegDocExample.pika
+++ b/examples/ppegDocExample.pika
@@ -1,0 +1,11 @@
+include('systools.pika');
+include('stdlib.pika');
+include(run.root # '../tools/ppeg/ppeg.pika');
+
+src = load(run.root # 'digits.ppeg');
+parseDigits = ppeg.compileFunction(src);
+
+assert(> parseDigits('12345'));
+assert(> !parseDigits('12a45'));
+
+print('Example completed successfully');


### PR DESCRIPTION
## Summary
- document how to run the digits example from any directory
- add `examples/ppegDocExample.pika` for the documentation snippet
- run the new example as part of the build on all targets

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a2b0c117483328ab8067787ada281