### PR TITLE
Add PikaCmd documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ After building, `PikaCmd` can be installed system-wide using `InstallPika.sh`, w
 18 sudo cp systools.pika /usr/local/bin/
 ```
 
+For a detailed overview of `PikaCmd`, the helper script `systools.pika` and how
+to write portable build scripts, see
+[docs/PikaCmd Documentation.txt](docs/PikaCmd%20Documentation.txt).
+
 The file `DownloadAndInstallReadMe.txt` also provides one-line boot-strap commands for Windows or Unix systems to download and install PikaScript:
 
 ```

--- a/docs/PikaCmd Documentation.txt
+++ b/docs/PikaCmd Documentation.txt
@@ -1,0 +1,78 @@
+PikaCmd
+#######
+
+What is PikaCmd?
+================
+
+ PikaCmd is the command line runner for PikaScript programs. It bundles the
+ language runtime and standard library into a standalone executable so that
+ scripts can be executed directly from a shell.
+
+Building
+========
+
+ The tool is built from the sources in `tools/PikaCmd/SourceDistribution`.
+ Run `BuildPikaCmd.sh` (or the `.cmd` variant on Windows) which compiles
+ `PikaCmdAmalgam.cpp`, executes unit tests and produces a `PikaCmd` binary.
+
+      cd tools/PikaCmd/SourceDistribution
+      bash BuildPikaCmd.sh
+
+ After building, you can install `PikaCmd` and helper scripts system wide
+ using `InstallPika.sh` or `InstallPika.cmd`.
+
+systools.pika
+#############
+
+ The helper script `systools.pika` contains cross‑platform file utilities and an
+ improved `include` function used by many build scripts. Load it together with
+ `stdlib.pika` at the top of a script:
+
+      include('stdlib.pika');
+      include('systools.pika');
+
+Improved include
+----------------
+
+ The regular `include()` from `stdlib.pika` simply loads the named file. The
+ version in `systools.pika` first searches a list of directories and also tracks
+ which file is executing. The variable `::run.root` always contains the
+ directory of the currently running file. `include()` looks for the argument
+ relative to `run.root` followed by any paths added with
+ `include.addSearchPath()` or by setting the environment variable `PIKAINCLUDE`.
+ Already included files are skipped.
+
+ This mechanism allows scripts to locate other resources regardless of the
+ current working directory. `run()` is similarly wrapped so that it sets
+ `run.root` before executing the loaded source.
+
+Writing portable scripts
+========================
+
+ By using `systools.pika` and referencing files via `run.root`, a script can be
+ launched from any directory. Example:
+
+      include('stdlib.pika');
+      include('systools.pika');
+      include(run.root # '../tools/ppeg/ppeg.pika');
+
+      src = load(run.root # 'digits.ppeg');
+      parseDigits = ppeg.compileFunction(src);
+      assert(> parseDigits('123'));   # Works no matter the launch dir
+
+Built-in vs External Files
+-------------------------
+
+ PikaCmd provides a few scripts as built-ins so that they are always
+ available. `stdlib.pika` is among these and is embedded in the
+ executable together with `debug.pika`, `help.pika`, `interactive.pika`
+ and `default.pika`. When `load('stdlib.pika')` is called, the loader
+ first checks the working directory, then the directory of `PikaCmd`
+ itself and finally falls back to the built-in copy. This guarantees
+ that the standard library can be included even if the file is missing
+ on disk.
+
+ `systools.pika` is *not* internalized. It is distributed next to the
+ `PikaCmd` binary by `InstallPika.sh` and must exist on disk. The
+ overloaded `load()` still searches the current directory and the
+ executable directory, but there is no built-in fallback for this file.


### PR DESCRIPTION
## Summary
- document PikaCmd build process and systools.pika usage
- explain improved `include` and how to write portable scripts
- show where PikaCmd finds `stdlib.pika` vs `systools.pika`
- link new doc from README

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a350835c08332b105aabce4519bb3