### PR TITLE
Expand htmlify documentation with examples

### DIFF
--- a/docs/htmlify Documentation.txt
+++ b/docs/htmlify Documentation.txt
@@ -14,6 +14,7 @@ Markup Syntax
 
  The converter recognizes a small set of conventions:
 
+ -  Paragraphs indented 1–3 spaces are unwrapped while four or more spaces create `<pre>` blocks.
  -  Lines consisting solely of `#`, `=` or `-` create headers `<h1>`, `<h2>` and `<h3>`.
  -  `*bold*`, `/italic/` and `_underline_` produce `<b>`, `<i>` and `<u>` respectively.
  -  Backtick quoted sections ``code`` become `<tt>` blocks.
@@ -21,6 +22,12 @@ Markup Syntax
  -  Lists start with `*`, `-` or digits followed by `.` and may be nested using indentation.
  -  Tables are created by aligning columns with two spaces or more.
  -  `==========` inserts a horizontal rule.
+ -  Plain `http://` or `https://` links are automatically converted to `<a href>` tags.
+ -  Writing `[image.jpg]` (or `.png`, `.gif`) embeds the image; remote URLs inside brackets work too.
+ -  Referencing a header name exactly creates an internal link to that section if it appears elsewhere.
+ -  A `^` sequence forms superscript like `x^2`; spaces around the caret are not allowed.
+ -  Appending one or more `*` to a word marks a footnote and the text `**` defines it later.
+ -  Tables support header rows using a dashed line and row headers using `:` surrounded by spaces.
 
  Any text that does not match a special pattern is HTML escaped to ensure valid output.
 
@@ -36,9 +43,10 @@ Example Usage
      html = htmlify(src);
      save('docs/PikaScript Documentation.html', html);
 
- A helper script `tools/htmlifyFile.pika` performs the same conversion from the command line. Pass the text file and optionally a CSS file:
+ A helper script `tools/htmlifyFile.pika` performs the same conversion from the command line.
+ Pass the text file and optionally a CSS file:
 
-     PikaCmd tools/htmlifyFile.pika README.txt custom.css
+    PikaCmd tools/htmlifyFile.pika README.txt custom.css
 
 
 Known Limitations
@@ -47,4 +55,152 @@ Known Limitations
  -  Trailing spaces may affect formatting, particularly inside preformatted blocks.
  -  The implementation is tuned for this repository and may require adjustments for other
     input conventions.
+
+Example Document
+----------------
+
+ The following text demonstrates most features of `htmlify` and replaces the
+ previous `examples/test.txt` file:
+
+Main Header
+###########
+
+First Chapter
+=============
+
+Introduction
+------------
+
+Welcome you, welcome, welcome, welcome. I have absolutely nothing to say, so here goes nothing...
+
+We have two paragraphs.
+
+No, three paragraphs.
+And this one is broken into several
+lines.
+
+   If a paragraph
+starts with one to three spaces of
+indentation it will be "unwrapped"
+until...
+   The next indented line.
+
+You can write *bold* statements. And _underline_ of course. /Italic/ is written just like that. Enclose text in "grave accents" for teletype, `like this`.
+
+Urls, like http://www.soniccharge.com automatically turns into href's.
+
+A single line of `==========` (at least 10 of them) creates a horizontal divider.
+
+======================================================================================================================
+
+If you write the exact name of a header in this file it will become a reference. Like this: see Interesting Fruits. But only if this section isn't under the header you reference. So Main Header, First Chapter and Introduction won't become references right now.
+
+Local images can be inserted like this:
+
+[sleigh.jpg]
+
+(recognized extensions are `jpg`, `png` and `gif`).
+
+You can also insert remote images like this: [http://www.soniccharge.com/images/flags/SE.png]
+
+Local `.txt` and `.html` files can be referenced by simply writing a filename anywhere like this: test.txt. You can even reference an anchor inside a local html file. For example: test.html#Interesting_Fruits.
+
+`^` can be used for superscript in mathematical expressions, for example: x^3*5 + x^(7 * y). (Requirement: no space around `^` but at least one space somewhere before next `^`.)
+
+One or more asterisks after a word creates a reference to a footnote**...
+
+** which must be defined sooner or later
+
+Interesting Fruits
+------------------
+
+Lists are identified by 1), 2), 3) etc (for ordered lists) and *) or - (for unordered lists). With proper indentation you can create lists beneath other lists.
+
+1)  Apple
+    Is `good`
+
+    /for/ *you*
+2)  Orange
+
+        Beginning of sub-list
+
+        *) Hey
+        1) sub-list
+        2) yeah
+    *) You
+    *) The *rock* steady /crew/
+
+        End of sub-list
+
+3)  Banana
+    - boat
+        - party
+          *) night
+          tonight
+        - keep this
+          hard wrap
+        -  soften this
+          wrap
+          and this wrap
+           but break before but there
+          but not here
+
+          and extra space
+          before this section of two lines
+
+4)  http://www.soniccharge.com. Cool place to hang out.
+
+1) one
+2) two
+3) three
+
+Examples
+--------
+
+Examples are indented by four or more spaces and they will be put into <pre> </pre> sections. Take a look at the following example:
+
+    This is an example.
+    +-----------------------------+
+    |It uses a preformatted style.|
+    +-----------------------------+
+
+    and it continues to here.
+
+But stops here.
+
+Tables
+------
+
+Tables are created when a section contains a line with two or more consecutive spaces. These spaces divide the cells horizontally.
+
+This is a table without headers:
+
+various     things      arranged
+in          a           three
+by          three       square
+
+Cells can expand horizontally like this:
+
+  this is a long cell
+  shorter  cells  here
+           double cell
+  just 1
+
+This is a table with column headers:
+
+Year        Xylophones      Rusty nails     Unpolished bicycles
+----        ----------      -----------     -------------------
+1972  :     309             17              5.5
+1979  :     292             21293921        0
+1993  :     N/A             1               -5
+                                            /(returned five)/
+2009  :     - " -           2               10
+
+This is a table with row headers (remember, at least two spaces before and after `:`):
+
+First attempt   :   failed miserably
+Second attempt  :   things are getting better
+Third attempt   :   wooh, we are getting close now
+Fourth attempt  :   oh no, back to square 1
+
 


### PR DESCRIPTION
## Summary
- mention the indentation unwrap rule earlier
- embed the full `examples/test.txt` text as a new "Example Document" section
- reorder indentation bullet to head of markup syntax list
- drop obsolete instruction line from the embedded example

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_687cb6ca09dc83329b628a12225d6bef