### PR TITLE
Enable UTF‑8 conversion in htmlify

### DIFF
--- a/tools/UpdateHtmlDox.pika
+++ b/tools/UpdateHtmlDox.pika
@@ -26,7 +26,6 @@ tail = '
 ';
 map(@::STD_PATTERNS, "[?][?]{*}[?][?]" # STD_PATTERN_SUFFIX, '<font color="red">??{$1}??</font>');
 map(@::STD_PATTERNS, "=== {*} ===" # STD_PATTERN_SUFFIX, '<b>{$1}</b>');
-map(@::HTML_XLATE_PAIRS, 'å', '&aring;', 'ä', '&auml;', 'ö', '&ouml;', 'Å', '&Aring;', 'Ä', '&Auml;', 'Ö', '&Ouml;');
 save(run.root # '../docs/PikaScript Documentation.html',
      head # htmlify(load(run.root # '../docs/PikaScript Documentation.txt')) # tail);
 print(LF # '***** DONE *****' # LF);

--- a/tools/htmlify.pika
+++ b/tools/htmlify.pika
@@ -13,12 +13,18 @@
 */
 
 include('stdlib.pika');
+include('debug.pika');
 
 prune(@::HTML_XLATE_PAIRS);
 prune(@::HEADERS);
 prune(@::STD_PATTERNS);
 
 map(@::HTML_XLATE_PAIRS, ' ',' ' , "\n"," <br>\n" , '<','&lt;' , '>','&gt;' , '&','&amp;');
+map(@::HTML_XLATE_PAIRS
+                , 'å','&aring;' , 'ä','&auml;' , 'ö','&ouml;'
+                , 'Å','&Aring;' , 'Ä','&Auml;' , 'Ö','&Ouml;'
+                , 'é','&eacute;' , 'É','&Eacute;' , 'ü','&uuml;'
+                , 'Ü','&Uuml;' , 'ñ','&ntilde;' , 'Ñ','&Ntilde;');
 map(@::HEADERS, '#','h1' , '=','h2' , '-','h3');
 
 ::STD_PATTERN_SUFFIX = "{[.!?*)]*[,:;]~[ \n][]*}";
@@ -49,13 +55,40 @@ map(@::STD_PATTERNS
 		, "{[^ \n*]?*}{[*]?*}{[.!?)]*[,:;]~[ \n][]*}",								'{$1}<a href="#{footnote($2)}"><sup>{$2}</sup></a>'
 		);
 
+::decodeUtf8 = function {
+       args(@s);
+       b0 = ordinal(s{0});
+       if (b0 < 0x80) ( map(@r, 'cp', b0, 'len', 1) )
+       else if ((b0 & 0xE0) == 0xC0) (
+               map(@r, 'cp', ((b0 & 0x1F) << 6) | (ordinal(s{1}) & 0x3F), 'len', 2)
+       ) else if ((b0 & 0xF0) == 0xE0) (
+               map(@r, 'cp', ((b0 & 0x0F) << 12) | ((ordinal(s{1}) & 0x3F) << 6) | (ordinal(s{2}) & 0x3F), 'len', 3)
+       ) else if ((b0 & 0xF8) == 0xF0) (
+               map(@r, 'cp', ((b0 & 0x07) << 18) | ((ordinal(s{1}) & 0x3F) << 12) | ((ordinal(s{2}) & 0x3F) << 6) | (ordinal(s{3}) & 0x3F), 'len', 4)
+       ) else (
+               map(@r, 'cp', b0, 'len', 1)
+       )
+};
+
 ::html = function {
-	args(@in);
-	for (out = ''; in !== '';) {
-		out #= in{:i = find(in, HTML_XLATE_CHARS)};
-		if ((in = in{i:}) !== '') { out #= HTML_XLATE_PAIRS[in{0}]; in = in{1:} }
-	};
-	out
+       args(@in);
+       for (out = ''; in !== '';) {
+               i = 0;
+               while (i < length(in) && ordinal(in{i}) < 128 && !exists(@HTML_XLATE_PAIRS[in{i}])) ++i;
+               out #= in{:i};
+               in = in{i:};
+               if (in !== '') {
+                       if (exists(repl = @HTML_XLATE_PAIRS[in{0}])) {
+                               out #= repl;
+                               in = in{1:};
+                       } else {
+                               info = decodeUtf8(in);
+                               out #= '&#' # info['cp'] # ';';
+                               in = in{info['len']:};
+                       }
+               }
+       };
+       out
 };
 
 ::urlEncode = function {
@@ -99,9 +132,7 @@ map(@::STD_PATTERNS
 ::htmlify = function {
 	args(@src);
 	
-	clone(@::STD_PATTERNS, @patterns);
-	::HTML_XLATE_CHARS = '';
-	foreach(@::HTML_XLATE_PAIRS, >::HTML_XLATE_CHARS #= $1);
+       clone(@::STD_PATTERNS, @patterns);
 
 	footnotes.next = 0;
 	footnote => {


### PR DESCRIPTION
## Summary
- extend default translation pairs in `htmlify.pika`
- decode UTF‑8 sequences so non‑ASCII characters become HTML entities
- remove special mappings from `UpdateHtmlDox.pika`
- include `debug.pika` for easier troubleshooting

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_687cc7e9ad04833287744ecf760a9e80