### PR TITLE
Update install scripts to use GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ For a detailed overview of `PikaCmd`, the helper script `systools.pika` and how 
 The file `DownloadAndInstallReadMe.txt` also provides one-line boot-strap commands for Windows or Unix systems to download and install PikaScript:
 
 ```bat
-powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('http://nuedge.net/pikascript/install.bat','%TEMP%\\install.bat')" && %TEMP%\\install.bat
+powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/install.bat','%TEMP%\\install.bat')" && %TEMP%\\install.bat
 ```
 ```bash
-curl -s http://nuedge.net/pikascript/install.sh | sh
+curl -s https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 ```
 
 ## Running Scripts

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The file `DownloadAndInstallReadMe.txt` also provides one-line boot-strap comman
 powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/install.bat','%TEMP%\\install.bat')" && %TEMP%\\install.bat
 ```
 ```bash
-curl -s https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
+curl -sL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 ```
 
 ## Running Scripts

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The file `DownloadAndInstallReadMe.txt` also provides one-line boot-strap comman
 powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/install.bat','%TEMP%\\install.bat')" && %TEMP%\\install.bat
 ```
 ```bash
-curl -sL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
+curl -fsL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 ```
 
 ## Running Scripts

--- a/tools/PikaCmd/DownloadAndInstallPika.cmd
+++ b/tools/PikaCmd/DownloadAndInstallPika.cmd
@@ -65,7 +65,7 @@ REM This script upzip's files...
     >> j_unzip.vbs ECHO.
 
 ECHO Downloading, please wait...
-powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('http://nuedge.net/pikascript/PikaCmdSourceDistribution.zip','PikaCmdSourceDistribution.zip')" || GOTO error
+powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip','PikaCmdSourceDistribution.zip')" || GOTO error
 ECHO Extracting...
 cscript /B j_unzip.vbs PikaCmdSourceDistribution.zip || GOTO error
 DEL PikaCmdSourceDistribution.zip
@@ -80,5 +80,4 @@ EXIT /b 0
 
 :error
 ECHO Error %ERRORLEVEL%
-POPD
 EXIT /b %ERRORLEVEL%

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -7,7 +7,7 @@ if [ -z "${TMPDIR}" ]; then
 fi
 
 cd "${TMPDIR}"
-curl http://nuedge.net/pikascript/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
+curl https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
 mkdir -p "PikaCmd"
 cd "PikaCmd"
 rm -rf "SourceDistribution" || true

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -2,8 +2,8 @@
 set -e -o pipefail -u
 cd "$(dirname "$0")"
 
-if [ -z "${TMPDIR}" ]; then
-	TMPDIR="/tmp/"
+if [ -z "${TMPDIR:-}" ]; then
+        TMPDIR="/tmp/"
 fi
 
 cd "${TMPDIR}"

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -7,7 +7,7 @@ if [ -z "${TMPDIR}" ]; then
 fi
 
 cd "${TMPDIR}"
-curl https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
+curl -L https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
 mkdir -p "PikaCmd"
 cd "PikaCmd"
 rm -rf "SourceDistribution" || true

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -7,7 +7,7 @@ if [ -z "${TMPDIR:-}" ]; then
 fi
 
 cd "${TMPDIR}"
-curl -L https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
+curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
 mkdir -p "PikaCmd"
 cd "PikaCmd"
 rm -rf "SourceDistribution" || true

--- a/tools/PikaCmd/DownloadAndInstallReadMe.txt
+++ b/tools/PikaCmd/DownloadAndInstallReadMe.txt
@@ -11,7 +11,7 @@ MAC / UNIX
 
 One line install boot strap:
 	
-curl -s https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
+curl -sL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 
 On Ubuntu you may have to first install curl, g++ and 32-bit libraries:
 

--- a/tools/PikaCmd/DownloadAndInstallReadMe.txt
+++ b/tools/PikaCmd/DownloadAndInstallReadMe.txt
@@ -11,7 +11,7 @@ MAC / UNIX
 
 One line install boot strap:
 	
-curl -sL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
+curl -fsL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 
 On Ubuntu you may have to first install curl, g++ and 32-bit libraries:
 
@@ -19,4 +19,10 @@ On Ubuntu you may have to first install curl, g++ and 32-bit libraries:
 
 On FreeBSD you may have to first install sudo and gcc:
 
-	pkg install sudo gcc
+        pkg install sudo gcc
+
+To manually download the distribution on Unix systems you can run:
+
+        curl -fL -o PikaCmdSourceDistribution.tar.gz \
+                https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz
+        tar -xzvf PikaCmdSourceDistribution.tar.gz

--- a/tools/PikaCmd/DownloadAndInstallReadMe.txt
+++ b/tools/PikaCmd/DownloadAndInstallReadMe.txt
@@ -3,7 +3,7 @@ WINDOWS
 
 One line install boot strap:
 	
-	powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('http://nuedge.net/pikascript/install.bat','%TEMP%\install.bat')" && %TEMP%\install.bat
+powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/install.bat','%TEMP%\install.bat')" && %TEMP%\install.bat
 
 
 MAC / UNIX
@@ -11,7 +11,7 @@ MAC / UNIX
 
 One line install boot strap:
 	
-	curl -s http://nuedge.net/pikascript/install.sh | sh
+curl -s https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 
 On Ubuntu you may have to first install curl, g++ and 32-bit libraries:
 


### PR DESCRIPTION
## Summary
- update DownloadAndInstallPika scripts to fetch from GitHub releases
- adjust README and DownloadAndInstallReadMe with new one-line installers
- remove stray POPD from Windows installer

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68820866788883328100432cddd54c79