### PR TITLE
Fix GitHub release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       id: create
       uses: actions/create-release@v1
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ github.ref_name }}
         release_name: ${{ github.ref_name }}
         draft: false


### PR DESCRIPTION
## Summary
- ensure GitHub token is passed to create-release step

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68820a8f35cc8332b84a2c8d4db292c2