### PR TITLE
Fix GitHub release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Create release
       id: create
       uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref_name }}
         release_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- ensure the default token is passed via `GITHUB_TOKEN` env var in the release workflow

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68820a8f35cc8332b84a2c8d4db292c2