### PR TITLE
Fix GitHub release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   create_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create.outputs.upload_url }}
@@ -13,6 +15,8 @@ jobs:
     - name: Create release
       id: create
       uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref_name }}
         release_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- ensure the release job has write permissions for the contents scope so `actions/create-release` can authenticate

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68820a8f35cc8332b84a2c8d4db292c2