### PR TITLE
Update download scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https:/
 curl -fsL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 ```
 
+Both Windows and Unix installers first try to download the `.tar.gz` distribution
+and fall back to the `.zip` archive if needed.
+
 ## Running Scripts
 
 Once built, you can run a PikaScript program via:

--- a/tools/PikaCmd/DownloadAndInstallPika.cmd
+++ b/tools/PikaCmd/DownloadAndInstallPika.cmd
@@ -65,10 +65,21 @@ REM This script upzip's files...
     >> j_unzip.vbs ECHO.
 
 ECHO Downloading, please wait...
-powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip','PikaCmdSourceDistribution.zip')" || GOTO error
+powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz','PikaCmdSourceDistribution.tar.gz')" >NUL 2>NUL
+IF EXIST PikaCmdSourceDistribution.tar.gz (
+    SET ARCH=tar
+) ELSE (
+    powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip','PikaCmdSourceDistribution.zip')" || GOTO error
+    SET ARCH=zip
+)
 ECHO Extracting...
-cscript /B j_unzip.vbs PikaCmdSourceDistribution.zip || GOTO error
-DEL PikaCmdSourceDistribution.zip
+IF "%ARCH%"=="tar" (
+    tar -xzf PikaCmdSourceDistribution.tar.gz || GOTO error
+    DEL PikaCmdSourceDistribution.tar.gz
+) ELSE (
+    cscript /B j_unzip.vbs PikaCmdSourceDistribution.zip || GOTO error
+    DEL PikaCmdSourceDistribution.zip
+)
 CD SourceDistribution || GOTO error
 CALL BuildPikaCmd || GOTO error
 REM runas.exe /savecred /user:administrator /noprofile "CMD /K CD /D %TEMP%&&CD SourceDistribution&&InstallPika.cmd C:\WINDOWS&&CD ..&&RMDIR /S /Q SourceDistribution" || GOTO error

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -3,24 +3,26 @@ set -e -o pipefail -u
 cd "$(dirname "$0")"
 
 if [ -z "${TMPDIR:-}" ]; then
-        TMPDIR="/tmp/"
+	TMPDIR="/tmp/"
 fi
 
 cd "${TMPDIR}"
-ARCHIVE="tar.gz"
+echo "Downloading, please wait..."
+ARCH="tar"
 if ! curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz; then
-        ARCHIVE="zip"
-        curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip -o PikaCmdSourceDistribution.zip
+	ARCH="zip"
+	curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip -o PikaCmdSourceDistribution.zip
 fi
 mkdir -p "PikaCmd"
 cd "PikaCmd"
 rm -rf "SourceDistribution" || true
-if [ "$ARCHIVE" = "tar.gz" ]; then
-        tar -xzf "../PikaCmdSourceDistribution.tar.gz"
-        rm -f "../PikaCmdSourceDistribution.tar.gz"
+echo "Extracting..."
+if [ "$ARCH" = "tar" ]; then
+	tar -xzf "../PikaCmdSourceDistribution.tar.gz"
+	rm -f "../PikaCmdSourceDistribution.tar.gz"
 else
-        unzip -q "../PikaCmdSourceDistribution.zip"
-        rm -f "../PikaCmdSourceDistribution.zip"
+	unzip -q "../PikaCmdSourceDistribution.zip"
+	rm -f "../PikaCmdSourceDistribution.zip"
 fi
 cd "SourceDistribution"
 bash BuildPikaCmd.sh

--- a/tools/PikaCmd/DownloadAndInstallPika.sh
+++ b/tools/PikaCmd/DownloadAndInstallPika.sh
@@ -7,12 +7,21 @@ if [ -z "${TMPDIR:-}" ]; then
 fi
 
 cd "${TMPDIR}"
-curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz
+ARCHIVE="tar.gz"
+if ! curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz -o PikaCmdSourceDistribution.tar.gz; then
+        ARCHIVE="zip"
+        curl -fL https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip -o PikaCmdSourceDistribution.zip
+fi
 mkdir -p "PikaCmd"
 cd "PikaCmd"
 rm -rf "SourceDistribution" || true
-tar -xzf "../PikaCmdSourceDistribution.tar.gz"
-rm -f PikaCmdSourceDistribution.tar.gz
+if [ "$ARCHIVE" = "tar.gz" ]; then
+        tar -xzf "../PikaCmdSourceDistribution.tar.gz"
+        rm -f "../PikaCmdSourceDistribution.tar.gz"
+else
+        unzip -q "../PikaCmdSourceDistribution.zip"
+        rm -f "../PikaCmdSourceDistribution.zip"
+fi
 cd "SourceDistribution"
 bash BuildPikaCmd.sh
 bash InstallPika.sh

--- a/tools/PikaCmd/DownloadAndInstallReadMe.txt
+++ b/tools/PikaCmd/DownloadAndInstallReadMe.txt
@@ -24,5 +24,11 @@ On FreeBSD you may have to first install sudo and gcc:
 To manually download the distribution on Unix systems you can run:
 
         curl -fL -o PikaCmdSourceDistribution.tar.gz \
-                https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz
-        tar -xzvf PikaCmdSourceDistribution.tar.gz
+                https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.tar.gz \
+        || curl -fL -o PikaCmdSourceDistribution.zip \
+                https://github.com/malstrom72/PikaScript/releases/latest/download/PikaCmdSourceDistribution.zip
+        if [ -f PikaCmdSourceDistribution.tar.gz ]; then
+                tar -xzvf PikaCmdSourceDistribution.tar.gz
+        else
+                unzip PikaCmdSourceDistribution.zip
+        fi


### PR DESCRIPTION
## Summary
- ensure consistent download order for `.tar.gz` and `.zip`
- document installer behavior in README
- document manual curl example with `.tar.gz` preference

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6882aeba600083328f55ff8c08da4234