### PR TITLE
Fix asset upload permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
   linux:
     needs: create_release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: Build
@@ -54,6 +56,8 @@ jobs:
   windows:
     needs: create_release
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Summary
- grant `contents: write` permission to `linux` and `windows` jobs so upload-release-asset can authenticate

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6882b0aaf7088332b6611abdb0316d2a