### PR TITLE
Improve installer packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: bash ./build.sh
+    - name: Remove prebuilt PikaCmd
+      run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd
     - name: Package SourceDistribution
       run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
     - name: Upload release asset
@@ -50,6 +52,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: bash ./build.sh
+    - name: Remove prebuilt PikaCmd
+      run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd
     - name: Package SourceDistribution
       run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
 
@@ -63,6 +67,9 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Build
       run: .\build.cmd
+    - name: Remove prebuilt PikaCmd
+      shell: pwsh
+      run: Remove-Item -Force tools\PikaCmd\SourceDistribution\PikaCmd.exe -ErrorAction SilentlyContinue
     - name: Package SourceDistribution
       shell: pwsh
       run: Compress-Archive -Path tools/PikaCmd/SourceDistribution/* -DestinationPath PikaCmdSourceDistribution.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,23 +54,4 @@ jobs:
         asset_name: PikaCmdSourceDistribution.zip
         asset_content_type: application/zip
 
-  macos:
-    needs: create_release
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: bash ./build.sh
-
-
-  windows:
-    needs: create_release
-    runs-on: windows-latest
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ilammy/msvc-dev-cmd@v1
-    - name: Build
-      run: .\build.cmd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,16 +34,25 @@ jobs:
     - name: Build
       run: bash ./build.sh
     - name: Remove prebuilt PikaCmd
-      run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd
-    - name: Package SourceDistribution
+      run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd tools/PikaCmd/SourceDistribution/PikaCmd.exe
+    - name: Package SourceDistribution (tar)
       run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
-    - name: Upload release asset
+    - name: Package SourceDistribution (zip)
+      run: zip -r PikaCmdSourceDistribution.zip tools/PikaCmd/SourceDistribution
+    - name: Upload tarball
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
         asset_path: ./PikaCmdSourceDistribution.tar.gz
         asset_name: PikaCmdSourceDistribution.tar.gz
         asset_content_type: application/gzip
+    - name: Upload zip
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ./PikaCmdSourceDistribution.zip
+        asset_name: PikaCmdSourceDistribution.zip
+        asset_content_type: application/zip
 
   macos:
     needs: create_release
@@ -52,10 +61,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: bash ./build.sh
-    - name: Remove prebuilt PikaCmd
-      run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd
-    - name: Package SourceDistribution
-      run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
+
 
   windows:
     needs: create_release
@@ -67,16 +73,4 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Build
       run: .\build.cmd
-    - name: Remove prebuilt PikaCmd
-      shell: pwsh
-      run: Remove-Item -Force tools\PikaCmd\SourceDistribution\PikaCmd.exe -ErrorAction SilentlyContinue
-    - name: Package SourceDistribution
-      shell: pwsh
-      run: Compress-Archive -Path tools/PikaCmd/SourceDistribution/* -DestinationPath PikaCmdSourceDistribution.zip
-    - name: Upload release asset
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ./PikaCmdSourceDistribution.zip
-        asset_name: PikaCmdSourceDistribution.zip
-        asset_content_type: application/zip
+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('https:/
 ```bash
 curl -fsL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 ```
+These install scripts fetch only the `tools/PikaCmd/SourceDistribution` package from the
+latest release, keeping the download small for quick installation.
 
 ## Running Scripts
 

--- a/tools/PikaCmd/DownloadAndInstallReadMe.txt
+++ b/tools/PikaCmd/DownloadAndInstallReadMe.txt
@@ -13,6 +13,9 @@ One line install boot strap:
 	
 curl -fsL https://github.com/malstrom72/PikaScript/releases/latest/download/install.sh | sh
 
+The installer only downloads the `PikaCmd` source distribution from the latest release
+so the bootstrap is quick and lightweight.
+
 On Ubuntu you may have to first install curl, g++ and 32-bit libraries:
 
 	sudo apt-get install curl g++ g++-multilib


### PR DESCRIPTION
## Summary
- strip prebuilt `PikaCmd` from release assets
- clarify that installers fetch only the source distribution

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_688330f35d74833291ca0ca3118924d6