### PR TITLE
Fix release asset uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
       run: zip -r PikaCmdSourceDistribution.zip tools/PikaCmd/SourceDistribution
     - name: Upload tarball
       uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
         asset_path: ./PikaCmdSourceDistribution.tar.gz
@@ -48,6 +50,8 @@ jobs:
         asset_content_type: application/gzip
     - name: Upload zip
       uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
         asset_path: ./PikaCmdSourceDistribution.zip


### PR DESCRIPTION
## Summary
- add missing `GITHUB_TOKEN` for upload steps in the release workflow

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_688355b050248332a272f6dc40b0b66e