### PR TITLE
Fix PikaCmd package paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,14 @@ jobs:
     - name: Remove prebuilt PikaCmd
       run: rm -f tools/PikaCmd/SourceDistribution/PikaCmd tools/PikaCmd/SourceDistribution/PikaCmd.exe
     - name: Package SourceDistribution (tar)
-      run: tar -czf PikaCmdSourceDistribution.tar.gz tools/PikaCmd/SourceDistribution
+      run: |
+        tar -czf PikaCmdSourceDistribution.tar.gz \
+          -C tools/PikaCmd SourceDistribution
     - name: Package SourceDistribution (zip)
-      run: zip -r PikaCmdSourceDistribution.zip tools/PikaCmd/SourceDistribution
+      run: |
+        cd tools/PikaCmd
+        zip -r ../../PikaCmdSourceDistribution.zip SourceDistribution
+        cd ../../
     - name: Upload tarball
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
## Summary
- rename packaged folder for PikaCmd
- adapt install helpers to the new folder name
- revert unintended newline changes

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883603070fc8332acec10bd79e269d5