### PR TITLE
Improve docs on tags and captures

### DIFF
--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -39,13 +39,15 @@
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="compileFunction">compileFunction</a></h2>
 <h3><a name="Syntax">Syntax</a></h3>
-<pre>'parser' = ppeg.compileFunction(source, [@dd], [@iref], [rule = 'root'])<br></pre>
+<pre>'parser' = ppeg.compileFunction(source)<br></pre>
 <h3><a name="Description">Description</a></h3>
-<p>Converts <tt>source</tt> into a parser function and returns it. <tt>dd</tt> and <tt>iref</tt> <br>
-are references that set the default input for the generated parser. <br>
-<tt>dd</tt> supplies the initial <tt>$$</tt> value, often a container for parse <br>
-results but it may be any object. <tt>iref</tt> receives the index where <br>
-parsing stops. The optional <tt>rule</tt> argument selects the entry rule and <br>
+<p>Converts <tt>source</tt> into a parser function and returns it. <br>
+The returned parser has the following signature:</p>
+<pre>'success' = parser(text, [@dd], [@iref], [rule = 'root'])<br></pre>
+<p><tt>dd</tt> is a reference that supplies the starting <tt>$$</tt> value <br>
+and usually points at a container for the parse results. <br>
+<tt>iref</tt> receives the index where parsing stops. <br>
+The optional <tt>rule</tt> argument selects the entry rule and <br>
 defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -57,34 +57,42 @@ expression. The code may read or modify this value in place.</p>
 the input, construct data structures or call helper functions. Use <br>
 <tt>ppeg.fail()</tt> to abort parsing and report an error.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
-<p>Every rule receives a single argument in <tt>$$</tt>. Whatever the caller has <br>
-placed there can be read and modified, so <tt>$$</tt> acts as both input and <br>
-output. Unless you tag an expression the exact same object flows into <br>
-each sub-expression and any changes they make remain visible. Tagging <br>
-an expression with <tt>name:expr</tt> temporarily rebinds <tt>$$</tt> to <tt>$name</tt> while <br>
-<tt>expr</tt> runs. When it succeeds <tt>$name</tt> keeps the produced value and <tt>$$</tt> <br>
-reverts to its previous binding. Nothing is automatically merged back <br>
-into the caller&amp;#8217;s `$$`&amp;nbsp;&amp;mdash;&amp;nbsp;store the value yourself if <br>
+<p>Each rule receives an object in <tt>$$</tt>. If you do not tag any <br>
+expressions the same value flows through nested expressions and they may <br>
+modify it directly. A tag <tt>name:expr</tt> binds <tt>$$</tt> to <tt>$name</tt> only while <br>
+<tt>expr</tt> runs; when it succeeds <tt>$name</tt> keeps the result and <tt>$$</tt> reverts. <br>
+Nothing is copied back automatically&amp;#8212;store <tt>$name</tt> yourself if <br>
 needed.</p>
-<p>Prefixing an expression with <tt>name=</tt> or <tt>$$=</tt> captures the exact text <br>
-that the expression consumes before any actions run.  This is useful for <br>
-converting the substring to another datatype or keeping it for later <br>
-inspection.</p>
-<p>The following small grammar demonstrates these features by building a <br>
-dictionary from colon separated pairs:</p>
+<p><tt>name=expr</tt> or <tt>$$=expr</tt> saves the substring consumed by <tt>expr</tt> before <br>
+actions execute. This is handy for converting digits or preserving the <br>
+original text.</p>
+<p>The grammar below builds a dictionary from colon separated pairs:</p>
 <pre>root &lt;- "{" _            { $$ = new(Container) }<br>         pair ("," _ pair)* "}" _ !.<br><br>pair &lt;- key:ident ":" _ val:number { [$$][$key] = $val }<br><br>ident &lt;- $$=[a-zA-Z]+ _<br>number &lt;- digits=[0-9]+ { $$ = evaluate('+' # digits) } _<br>_ &lt;- [ \t\r\n]*<br></pre>
-<p>Here <tt>pair</tt> tags the identifier and number so its action can access them <br>
-as <tt>$key</tt> and <tt>$val</tt>.  The <tt>number</tt> rule captures the raw digits in <br>
-<tt>$digits</tt> before converting them to a numeric value.  Tagged and <br>
-captured variables remain available until the current rule finishes, allowing later actions to read or modify them.</p>
+<p><tt>pair</tt> tags the identifier and number so the action can read <tt>$key</tt> and <br>
+<tt>$val</tt>. <tt>number</tt> captures the digits in <tt>$digits</tt> before converting <br>
+them. Tagged variables remain available until the rule returns.</p>
 <h2><a name="Working_with_Custom_Fields">Working with Custom Fields</a></h2>
-<p>More elaborate grammars often store helper information in <tt>$$</tt> so that <br>
-multiple rules can share it.  The monolithic JSON example distributes <br>
-values into a pre-existing container designated by <tt>$$.target</tt>:</p>
-<pre>root   &lt;- _ { $$parser.null = coalesce(@$$.null, &lt;null&gt;); }<br>           (object / array) !.<br><br>object &lt;- "{"_ ( member (","_ member)* )? "}"_<br><br>member &lt;- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }<br>           v:value<br><br>value  &lt;- string                     { [$$.target] = $$ }<br>           / number                  { [$$.target] = $$ }<br>           / "true" _               { [$$.target] = true }<br>           / "false" _              { [$$.target] = false }<br>           / "null" _               { [$$.target] = $$parser.null }<br>           / object<br>           / array<br></pre>
-<p>The caller initializes <tt>$$.target</tt> to a container and each rule stores <br>
-its result at that location.  Because <tt>target</tt> is just a field inside <br>
-<tt>$$</tt> it is visible to all sub-expressions until the rule returns.</p>
+<table>
+<tr>
+<td colspan=4>Grammars often pass context in <tt>$$</tt>.</td><td>The monolithic JSON parser</td>
+</tr>
+<tr>
+<td colspan=5>writes results into the container referenced by <tt>$$.target</tt>:</td>
+</tr>
+<tr>
+<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>
+</tr>
+<tr>
+<td>&nbsp;</td><td>root</td><td colspan=3>&lt;- _ { $$parser.null = coalesce(@$$.null, &lt;null&gt;); }</td>
+</tr>
+<tr>
+<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>(object / array) !.</td><td>&nbsp;</td>
+</tr>
+</table>
+<pre>object &lt;- "{"_ ( member (","_ member)* )? "}"_<br><br>member &lt;- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }<br>           v:value<br><br>value  &lt;- string                     { [$$.target] = $$ }<br>           / number                  { [$$.target] = $$ }<br>           / "true" _               { [$$.target] = true }<br>           / "false" _              { [$$.target] = false }<br>           / "null" _               { [$$.target] = $$parser.null }<br>           / object<br>           / array<br></pre>
+<p>Initialize <tt>$$.target</tt> before parsing; each rule stores its result in <br>
+that field.  Because <tt>target</tt> is just a member of <tt>$$</tt>, all nested <br>
+rules see it until the current rule finishes.</p>
 
 	</body>
 </html>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -37,6 +37,54 @@
 <h2><a name="Example:_Using_the_Local_Compiler">Example: Using the Local Compiler</a></h2>
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
+<h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
+<p>PPEG grammars can embed blocks of PikaScript that run when the preceding <br>
+expression succeeds. These action blocks appear inside braces <tt>{}</tt> and end <br>
+with a <tt>;true</tt> so the parser always continues after running the code. <br>
+Before the action executes <tt>$$</tt> already holds the value produced by the <br>
+expression. The code may read or modify this value in place.</p>
+<p>The following helper variables are available inside an action:</p>
+
+<ul>
+<li><tt>$$</tt> &#8211; current result container. Use <tt>$$=</tt> before an expression to capture<br>the raw substring it consumes.
+<br></li>
+<li><tt>$$s</tt> &#8211; the source string being parsed.<br></li>
+<li><tt>$$i</tt> &#8211; the index within <tt>$$s</tt> where the next character will be read.<br></li>
+<li><tt>$$parser</tt> &#8211; dictionary holding all generated parser functions. Global<br>grammars populate this dictionary while local compilers return it.
+</li>
+</ul>
+<p>These identifiers are expanded by the compiler so that actions can inspect <br>
+the input, construct data structures or call helper functions. Use <br>
+<tt>ppeg.fail()</tt> to abort parsing and report an error.</p>
+<h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
+<p>Every rule receives a single argument in <tt>$$</tt>. Whatever the caller has <br>
+placed there can be read and modified, so <tt>$$</tt> acts as both input and <br>
+output. Unless you tag an expression the exact same object flows into <br>
+each sub-expression and any changes they make remain visible. Tagging <br>
+an expression with <tt>name:expr</tt> temporarily rebinds <tt>$$</tt> to <tt>$name</tt> while <br>
+<tt>expr</tt> runs. When it succeeds <tt>$name</tt> keeps the produced value and <tt>$$</tt> <br>
+reverts to its previous binding. Nothing is automatically merged back <br>
+into the caller&amp;#8217;s `$$`&amp;nbsp;&amp;mdash;&amp;nbsp;store the value yourself if <br>
+needed.</p>
+<p>Prefixing an expression with <tt>name=</tt> or <tt>$$=</tt> captures the exact text <br>
+that the expression consumes before any actions run.  This is useful for <br>
+converting the substring to another datatype or keeping it for later <br>
+inspection.</p>
+<p>The following small grammar demonstrates these features by building a <br>
+dictionary from colon separated pairs:</p>
+<pre>root &lt;- "{" _            { $$ = new(Container) }<br>         pair ("," _ pair)* "}" _ !.<br><br>pair &lt;- key:ident ":" _ val:number { [$$][$key] = $val }<br><br>ident &lt;- $$=[a-zA-Z]+ _<br>number &lt;- digits=[0-9]+ { $$ = evaluate('+' # digits) } _<br>_ &lt;- [ \t\r\n]*<br></pre>
+<p>Here <tt>pair</tt> tags the identifier and number so its action can access them <br>
+as <tt>$key</tt> and <tt>$val</tt>.  The <tt>number</tt> rule captures the raw digits in <br>
+<tt>$digits</tt> before converting them to a numeric value.  Tagged and <br>
+captured variables remain available until the current rule finishes, allowing later actions to read or modify them.</p>
+<h2><a name="Working_with_Custom_Fields">Working with Custom Fields</a></h2>
+<p>More elaborate grammars often store helper information in <tt>$$</tt> so that <br>
+multiple rules can share it.  The monolithic JSON example distributes <br>
+values into a pre-existing container designated by <tt>$$.target</tt>:</p>
+<pre>root   &lt;- _ { $$parser.null = coalesce(@$$.null, &lt;null&gt;); }<br>           (object / array) !.<br><br>object &lt;- "{"_ ( member (","_ member)* )? "}"_<br><br>member &lt;- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }<br>           v:value<br><br>value  &lt;- string                     { [$$.target] = $$ }<br>           / number                  { [$$.target] = $$ }<br>           / "true" _               { [$$.target] = true }<br>           / "false" _              { [$$.target] = false }<br>           / "null" _               { [$$.target] = $$parser.null }<br>           / object<br>           / array<br></pre>
+<p>The caller initializes <tt>$$.target</tt> to a container and each rule stores <br>
+its result at that location.  Because <tt>target</tt> is just a field inside <br>
+<tt>$$</tt> it is visible to all sub-expressions until the rule returns.</p>
 
 	</body>
 </html>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -37,6 +37,12 @@
 <h2><a name="Example:_Using_the_Local_Compiler">Example: Using the Local Compiler</a></h2>
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
+<p>CompileFunction Arguments <br>
+------------------------</p>
+<p><tt>ppeg.compileFunction(src, @outFunc, dd=nil, iref=nil, rule='root')</tt> returns a <br>
+new parsing function built from <tt>src</tt>. When <tt>@outFunc</tt> is supplied the function <br>
+is also stored there. The remaining parameters become the defaults for the <br>
+parser's own arguments, matching the ones used by <tt>ppeg.parse</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>
@@ -54,12 +60,12 @@ action can inspect or modify this value directly.</p>
 <p>These identifiers let actions look at the input, build data structures, or <br>
 report errors via <tt>ppeg.fail()</tt>.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
-<p>Every rule takes one argument called <tt>$$</tt>. It also serves as the return value. <br>
-When subexpressions are written without tags the same object flows through them <br>
-all and may be modified in place. A tagged expression <tt>name:expr</tt> temporarily <br>
-sets <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt> runs. After it succeeds <tt>$name</tt> holds the <br>
-result and <tt>$$</tt> reverts to the original object so the rule can decide how to <br>
-use the new value.</p>
+<p>Every rule takes <tt>$$</tt> as its input and also returns it. Untagged <br>
+subexpressions therefore share one container and may update it in place. A <br>
+tagged expression <tt>name:expr</tt> temporarily binds <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt> <br>
+runs. When the expression finishes, <tt>$name</tt> contains the produced value and <br>
+<tt>$$</tt> again refers to the outer container so the rule can decide how to use the <br>
+new data.</p>
 <p>A capture <tt>name=expr</tt> (or <tt>$$=expr</tt>) grabs the substring consumed by <tt>expr</tt> <br>
 before any action executes. The action can then convert this text or store it.</p>
 <p>The grammar below builds a dictionary from colon-separated pairs:</p>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -41,11 +41,11 @@
 <pre>'parser' = ppeg.compileFunction(source)<br></pre>
 <p>Converts <tt>source</tt> into a parser function. The generated parser has the <br>
 following signature:</p>
-<pre>'success' = parser(text, [@dd], [@iref], [rule = 'root'])<br></pre>
-<p><tt>dd</tt> is a reference supplying the starting value of <tt>$$</tt>, normally a <br>
-container to collect results.  <tt>iref</tt> receives the index where parsing <br>
-stopped.  The optional <tt>rule</tt> argument selects the entry rule and <br>
-defaults to <tt>'root'</tt>.</p>
+<pre>'success' = parser(text, [@result], [@endIndex], [rule = 'root'])<br></pre>
+<p><tt>result</tt> is a reference supplying the starting value of <tt>$$</tt>, normally a <br>
+container to collect results.  <tt>endIndex</tt> receives the position where <br>
+parsing stopped.  The optional <tt>rule</tt> argument selects the entry rule <br>
+and defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
  inside braces <tt>{}</tt>. Before the block runs, <tt>$$</tt> already contains the value <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -39,16 +39,28 @@
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="compileFunction">compileFunction</a></h2>
 <h3><a name="Syntax">Syntax</a></h3>
-<pre>parser = ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule = 'root']]]])<br></pre>
+<pre>parser = ppeg.compileFunction(source [, dd [, iref [, rule = 'root']]])<br></pre>
 <h3><a name="Description">Description</a></h3>
-<p>Converts <tt>source</tt> into a parser function. If <tt>@outFunc</tt> is supplied, <br>
-the generated parser is stored there and the call returns <tt>true</tt>; otherwise it <br>
-returns the new parser.</p>
-<p><tt>dd</tt> and <tt>iref</tt> customize how the generated parser manages state. <tt>dd</tt> is the <br>
-container passed to each rule when no tag rebinding occurs so rules can add to a <br>
-shared dictionary. <tt>iref</tt> is an lvalue that receives the index of the first <br>
-unconsumed character once parsing finishes. The optional <tt>rule</tt> parameter <br>
-selects the entry point and defaults to <tt>'root'</tt>.</p>
+<table>
+<tr>
+<td>Converts <tt>source</tt> into a parser function and returns it.</td><td><tt>dd</tt> and</td>
+</tr>
+<tr>
+<td colspan=2><tt>iref</tt> are references that become the defaults for the generated</td>
+</tr>
+<tr>
+<td colspan=2>parser. <tt>dd</tt> supplies the starting <tt>$$</tt> value which typically holds the</td>
+</tr>
+<tr>
+<td colspan=2>output dictionary. <tt>iref</tt> receives the character index where parsing</td>
+</tr>
+<tr>
+<td colspan=2>stopped. The optional <tt>rule</tt> argument selects the entry rule and</td>
+</tr>
+<tr>
+<td>defaults to <tt>'root'</tt>.</td><td>&nbsp;</td>
+</tr>
+</table>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>
@@ -66,23 +78,35 @@ action can inspect or modify this value directly.</p>
 <p>These identifiers let actions look at the input, build data structures, or <br>
 report errors via <tt>ppeg.fail()</tt>.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
-<p>Every rule takes <tt>$$</tt> as its input and also returns it. Untagged <br>
-subexpressions therefore share one container and may update it in place. A <br>
-tagged expression <tt>name:expr</tt> temporarily binds <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt> <br>
-runs. When the expression finishes, <tt>$name</tt> contains the produced value and <br>
-<tt>$$</tt> again refers to the outer container so the rule can decide how to use the <br>
-new data.</p>
-<p>A capture <tt>name=expr</tt> (or <tt>$$=expr</tt>) grabs the substring consumed by <tt>expr</tt> <br>
-before any action executes. The action can then convert this text or store it.</p>
+<table>
+<tr>
+<td colspan=2>Each rule receives and returns <tt>$$</tt>.</td><td colspan=3>Without a tag, called rules work on the</td>
+</tr>
+<tr>
+<td>same container.</td><td colspan=4>Tagging with <tt>name:expr</tt> binds <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt></td>
+</tr>
+<tr>
+<td colspan=4>runs and leaves <tt>$name</tt> defined for the rest of the rule.</td><td>If <tt>$$</tt> is a</td>
+</tr>
+<tr>
+<td colspan=3>dictionary, the tag is also stored there automatically.</td><td colspan=2>A capture</td>
+</tr>
+<tr>
+<td colspan=5><tt>name=expr</tt> (or <tt>$$=expr</tt>) records the consumed substring before any actions</td>
+</tr>
+<tr>
+<td>run.</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>
+</tr>
+</table>
 <p>The grammar below builds a dictionary from colon-separated pairs:</p>
 <pre>root &lt;- "{" _            { $$ = new(Container) }<br>         pair ("," _ pair)* "}" _ !.<br><br>pair &lt;- key:ident ":" _ val:number { [$$][$key] = $val }<br><br>ident &lt;- $$=[a-zA-Z]+ _<br>number &lt;- digits=[0-9]+ { $$ = evaluate('+' # digits) } _<br>_ &lt;- [ \t\r\n]*<br></pre>
 <p><tt>pair</tt> tags the identifier and number so the action can read <tt>$key</tt> and <br>
-<tt>$val</tt>. <tt>number</tt> captures the digits in <tt>$digits</tt> before converting <br>
+<tt>$val</tt>.  <tt>number</tt> captures the digits in <tt>$digits</tt> before converting <br>
 them. Tagged variables remain available until the rule returns.</p>
 <h2><a name="Working_with_Custom_Fields">Working with Custom Fields</a></h2>
 <table>
 <tr>
-<td colspan=4>Grammars often pass context in <tt>$$</tt>.</td><td>The monolithic JSON parser</td>
+<td colspan=4>Grammars often store context in a field of <tt>$$</tt>.</td><td>The monolithic JSON parser</td>
 </tr>
 <tr>
 <td colspan=5>writes results into the container referenced by <tt>$$.target</tt>:</td>
@@ -98,9 +122,14 @@ them. Tagged variables remain available until the rule returns.</p>
 </tr>
 </table>
 <pre>object &lt;- "{"_ ( member (","_ member)* )? "}"_<br><br>member &lt;- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }<br>           v:value<br><br>value  &lt;- string                     { [$$.target] = $$ }<br>           / number                  { [$$.target] = $$ }<br>           / "true" _               { [$$.target] = true }<br>           / "false" _              { [$$.target] = false }<br>           / "null" _               { [$$.target] = $$parser.null }<br>           / object<br>           / array<br></pre>
-<p>Initialize <tt>$$.target</tt> before parsing; each rule stores its result in <br>
-that field.  Because <tt>target</tt> is just a member of <tt>$$</tt>, all nested <br>
-rules see it until the current rule finishes.</p>
+<table>
+<tr>
+<td>Initialize <tt>$$.target</tt> before parsing.</td><td>Because <tt>target</tt> is just a member of</td>
+</tr>
+<tr>
+<td colspan=2><tt>$$</tt>, all nested rules see it until the current rule finishes.</td>
+</tr>
+</table>
 
 	</body>
 </html>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -37,15 +37,17 @@
 <h2><a name="Example:_Using_the_Local_Compiler">Example: Using the Local Compiler</a></h2>
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
-<p>CompileFunction Arguments <br>
-------------------------</p>
-<p><tt>ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule='root']]]])</tt> <br>
-builds a parser from <tt>source</tt>. With <tt>@outFunc</tt> the compiled parser is stored <br>
-there and the call returns <tt>true</tt> on success; otherwise the new parser is <br>
-returned.</p>
-<p><tt>dd</tt> and <tt>iref</tt> become the parser's default <tt>dd</tt> and <tt>iref</tt> parameters so you <br>
-may share a dictionary container and a position reference. <tt>rule</tt> chooses the <br>
-starting rule and defaults to <tt>'root'</tt>.</p>
+<h2><a name="compileFunction">compileFunction</a></h2>
+<h3><a name="Syntax">Syntax</a></h3>
+<pre>parser = ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule = 'root']]]])<br></pre>
+<h3><a name="Description">Description</a></h3>
+<p>Converts &lt;code&gt;source&lt;/code&gt; into a parser function. If &lt;code&gt;@outFunc&lt;/code&gt; is supplied, <br>
+the generated parser is stored there and the call returns &lt;code&gt;true&lt;/code&gt;; otherwise it <br>
+returns the new parser.</p>
+<p>&lt;code&gt;dd&lt;/code&gt; and &lt;code&gt;iref&lt;/code&gt; establish the default dictionary container and index <br>
+reference for the parser. They let callers provide an external container and position <br>
+variable that each rule will update. The optional &lt;code&gt;rule&lt;/code&gt; parameter selects the <br>
+starting rule and defaults to &lt;code&gt;'root'&lt;/code&gt;.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -38,83 +38,26 @@
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="compileFunction">compileFunction</a></h2>
-<pre>'parser' = ppeg.compileFunction(source)<br></pre>
-<p>Converts <tt>source</tt> into a parser function. The generated parser has the <br>
-following signature:</p>
-<pre>'success' = parser(text, [@result], [@endIndex], [rule = 'root'])<br></pre>
-<p><tt>result</tt> is a reference supplying the starting value of <tt>$$</tt>, normally a <br>
-container to collect results.  <tt>endIndex</tt> receives the position where <br>
-parsing stopped.  The optional <tt>rule</tt> argument selects the entry rule <br>
-and defaults to <tt>'root'</tt>.</p>
+<pre>&gt;parser = ppeg.compileFunction(source)<br></pre>
+<p>Converts <tt>source</tt> into a parser function. The generated parser has the following signature:</p>
+<pre>?success = parser(text, [@result], [@endIndex], [rule = 'root'])<br></pre>
+<p><tt>result</tt> is a reference supplying the starting value of <tt>$$</tt>, normally a container to collect results. <tt>endIndex</tt> receives the position where parsing stopped. The optional <tt>rule</tt> argument selects the entry rule and defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
-<p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
- inside braces <tt>{}</tt>. Before the block runs, <tt>$$</tt> already contains the value <br>
- produced by the expression. The action can inspect or modify this value <br>
- directly.</p>
+<p>PPEG grammars may attach PikaScript code to an expression. The code is written inside braces <tt>{}</tt>. Before the block runs, <tt>$$</tt> already contains the value produced by the expression. The action can inspect or modify this value directly.</p>
 <p>The following helpers are available inside an action:</p>
 
 <ul>
-<li><tt>$$</tt> &#8211; current value passed between rules. Use <tt>name=expr</tt> or <tt>$$=expr</tt><br>to capture the substring an expression consumes.
-<br></li>
+<li><tt>$$</tt> &#8211; current value passed between rules.<br></li>
 <li><tt>$$s</tt> &#8211; the source string being parsed.<br></li>
 <li><tt>$$i</tt> &#8211; index within <tt>$$s</tt> for the next character.<br></li>
 <li><tt>$$parser</tt> &#8211; dictionary holding all generated parser functions.</li>
 </ul>
-<p>These identifiers let actions look at the input, build data structures, or <br>
-report errors via <tt>ppeg.fail()</tt>.</p>
+<p>These identifiers let actions look at the input, build data structures, or report errors via <tt>ppeg.fail()</tt>.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
-<table>
-<tr>
-<td colspan=5>Each rule receives <tt>$$</tt> as both input and output.</td><td>Without a tag, sub-rules</td>
-</tr>
-<tr>
-<td colspan=3>operate on the same value.</td><td colspan=3>Tagging with <tt>name:expr</tt> temporarily rebinds <tt>$$</tt></td>
-</tr>
-<tr>
-<td colspan=4>to <tt>$name</tt> while <tt>expr</tt> runs.</td><td colspan=2>Afterward <tt>$name</tt> holds the result and can be</td>
-</tr>
-<tr>
-<td colspan=2>used in later actions.</td><td colspan=4>When <tt>$$</tt> is a dictionary the tag is also stored there</td>
-</tr>
-<tr>
-<td>automatically.</td><td colspan=5>A capture <tt>name=expr</tt> (or <tt>$$=expr</tt>) stores the consumed</td>
-</tr>
-<tr>
-<td colspan=5>substring before any attached actions run.</td><td>&nbsp;</td>
-</tr>
-</table>
+<p>Each rule receives <tt>$$</tt> as both input and output. Without a tag, sub-rules operate on the same value. Tagging with <tt>name:expr</tt> temporarily rebinds <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt> runs. Afterward <tt>$name</tt> holds the result and can be used in later actions. A capture <tt>name=expr`(or `$$=expr</tt>) stores the consumed substring before any attached actions run.</p>
 <p>The grammar below builds a dictionary from colon-separated pairs:</p>
-<pre>root &lt;- "{" _            { $$ = new(Container) }<br>         pair ("," _ pair)* "}" _ !.<br><br>pair &lt;- key:ident ":" _ val:number { [$$][$key] = $val }<br><br>ident &lt;- $$=[a-zA-Z]+ _<br>number &lt;- digits=[0-9]+ { $$ = evaluate('+' # digits) } _<br>_ &lt;- [ \t\r\n]*<br></pre>
-<p><tt>pair</tt> tags the identifier and number so the action can read <tt>$key</tt> and <br>
-<tt>$val</tt>.  <tt>number</tt> captures the digits in <tt>$digits</tt> before converting <br>
-them. Tagged variables remain available until the rule returns.</p>
-<h2><a name="Working_with_Custom_Fields">Working with Custom Fields</a></h2>
-<table>
-<tr>
-<td colspan=4>Grammars often store context in a field of <tt>$$</tt>.</td><td>The monolithic JSON parser</td>
-</tr>
-<tr>
-<td colspan=5>writes results into the container referenced by <tt>$$.target</tt>:</td>
-</tr>
-<tr>
-<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td><td>root</td><td colspan=3>&lt;- _ { $$parser.null = coalesce(@$$.null, &lt;null&gt;); }</td>
-</tr>
-<tr>
-<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>(object / array) !.</td><td>&nbsp;</td>
-</tr>
-</table>
-<pre>object &lt;- "{"_ ( member (","_ member)* )? "}"_<br><br>member &lt;- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }<br>           v:value<br><br>value  &lt;- string                     { [$$.target] = $$ }<br>           / number                  { [$$.target] = $$ }<br>           / "true" _               { [$$.target] = true }<br>           / "false" _              { [$$.target] = false }<br>           / "null" _               { [$$.target] = $$parser.null }<br>           / object<br>           / array<br></pre>
-<table>
-<tr>
-<td>Initialize <tt>$$.target</tt> before parsing.</td><td>Because <tt>target</tt> is just a member of</td>
-</tr>
-<tr>
-<td colspan=2><tt>$$</tt>, all nested rules see it until the current rule finishes.</td>
-</tr>
-</table>
+<pre>root   &lt;-  "{" _                           { $$ = new(Container) }<br>           pair ("," _ pair)* "}" _ !.<br><br>pair   &lt;-  key:ident ":" _ val:number _    { [$$][$key] = $val }<br><br>ident  &lt;-  $$=[a-zA-Z]+ _<br>number &lt;-  digits=[0-9]+                   { $$ = evaluate('+' # digits) }<br>           _<br><br>_      &lt;-  [ \t\r\n]*<br></pre>
+<p><tt>pair</tt> tags the identifier and number so the action can read <tt>$key</tt> and <tt>$val</tt>. <tt>number</tt> captures the digits in <tt>$digits</tt> before converting them. Tagged variables remain available until the rule returns. </p>
 
 	</body>
 </html>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -41,13 +41,14 @@
 <h3><a name="Syntax">Syntax</a></h3>
 <pre>parser = ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule = 'root']]]])<br></pre>
 <h3><a name="Description">Description</a></h3>
-<p>Converts &lt;code&gt;source&lt;/code&gt; into a parser function. If &lt;code&gt;@outFunc&lt;/code&gt; is supplied, <br>
-the generated parser is stored there and the call returns &lt;code&gt;true&lt;/code&gt;; otherwise it <br>
+<p>Converts <tt>source</tt> into a parser function. If <tt>@outFunc</tt> is supplied, <br>
+the generated parser is stored there and the call returns <tt>true</tt>; otherwise it <br>
 returns the new parser.</p>
-<p>&lt;code&gt;dd&lt;/code&gt; and &lt;code&gt;iref&lt;/code&gt; establish the default dictionary container and index <br>
-reference for the parser. They let callers provide an external container and position <br>
-variable that each rule will update. The optional &lt;code&gt;rule&lt;/code&gt; parameter selects the <br>
-starting rule and defaults to &lt;code&gt;'root'&lt;/code&gt;.</p>
+<p><tt>dd</tt> and <tt>iref</tt> customize how the generated parser manages state. <tt>dd</tt> is the <br>
+container passed to each rule when no tag rebinding occurs so rules can add to a <br>
+shared dictionary. <tt>iref</tt> is an lvalue that receives the index of the first <br>
+unconsumed character once parsing finishes. The optional <tt>rule</tt> parameter <br>
+selects the entry point and defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -39,10 +39,13 @@
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <p>CompileFunction Arguments <br>
 ------------------------</p>
-<p><tt>ppeg.compileFunction(src, @outFunc, dd=nil, iref=nil, rule='root')</tt> returns a <br>
-new parsing function built from <tt>src</tt>. When <tt>@outFunc</tt> is supplied the function <br>
-is also stored there. The remaining parameters become the defaults for the <br>
-parser's own arguments, matching the ones used by <tt>ppeg.parse</tt>.</p>
+<p><tt>ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule='root']]]])</tt> <br>
+builds a parser from <tt>source</tt>. With <tt>@outFunc</tt> the compiled parser is stored <br>
+there and the call returns <tt>true</tt> on success; otherwise the new parser is <br>
+returned.</p>
+<p><tt>dd</tt> and <tt>iref</tt> become the parser's default <tt>dd</tt> and <tt>iref</tt> parameters so you <br>
+may share a dictionary container and a position reference. <tt>rule</tt> chooses the <br>
+starting rule and defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -38,35 +38,31 @@
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
-<p>PPEG grammars can embed blocks of PikaScript that run when the preceding <br>
-expression succeeds. These action blocks appear inside braces <tt>{}</tt> and end <br>
-with a <tt>;true</tt> so the parser always continues after running the code. <br>
-Before the action executes <tt>$$</tt> already holds the value produced by the <br>
-expression. The code may read or modify this value in place.</p>
-<p>The following helper variables are available inside an action:</p>
+<p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
+inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>
+block runs, <tt>$$</tt> already contains the value produced by the expression. The <br>
+action can inspect or modify this value directly.</p>
+<p>The following helpers are available inside an action:</p>
 
 <ul>
-<li><tt>$$</tt> &#8211; current result container. Use <tt>$$=</tt> before an expression to capture<br>the raw substring it consumes.
+<li><tt>$$</tt> &#8211; current result container. Use <tt>$$=</tt> before an expression to capture<br>the substring it consumes.
 <br></li>
 <li><tt>$$s</tt> &#8211; the source string being parsed.<br></li>
-<li><tt>$$i</tt> &#8211; the index within <tt>$$s</tt> where the next character will be read.<br></li>
-<li><tt>$$parser</tt> &#8211; dictionary holding all generated parser functions. Global<br>grammars populate this dictionary while local compilers return it.
-</li>
+<li><tt>$$i</tt> &#8211; index within <tt>$$s</tt> for the next character.<br></li>
+<li><tt>$$parser</tt> &#8211; dictionary holding all generated parser functions.</li>
 </ul>
-<p>These identifiers are expanded by the compiler so that actions can inspect <br>
-the input, construct data structures or call helper functions. Use <br>
-<tt>ppeg.fail()</tt> to abort parsing and report an error.</p>
+<p>These identifiers let actions look at the input, build data structures, or <br>
+report errors via <tt>ppeg.fail()</tt>.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
-<p>Each rule receives an object in <tt>$$</tt>. If you do not tag any <br>
-expressions the same value flows through nested expressions and they may <br>
-modify it directly. A tag <tt>name:expr</tt> binds <tt>$$</tt> to <tt>$name</tt> only while <br>
-<tt>expr</tt> runs; when it succeeds <tt>$name</tt> keeps the result and <tt>$$</tt> reverts. <br>
-Nothing is copied back automatically&amp;#8212;store <tt>$name</tt> yourself if <br>
-needed.</p>
-<p><tt>name=expr</tt> or <tt>$$=expr</tt> saves the substring consumed by <tt>expr</tt> before <br>
-actions execute. This is handy for converting digits or preserving the <br>
-original text.</p>
-<p>The grammar below builds a dictionary from colon separated pairs:</p>
+<p>Every rule takes one argument called <tt>$$</tt>. It also serves as the return value. <br>
+When subexpressions are written without tags the same object flows through them <br>
+all and may be modified in place. A tagged expression <tt>name:expr</tt> temporarily <br>
+sets <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt> runs. After it succeeds <tt>$name</tt> holds the <br>
+result and <tt>$$</tt> reverts to the original object so the rule can decide how to <br>
+use the new value.</p>
+<p>A capture <tt>name=expr</tt> (or <tt>$$=expr</tt>) grabs the substring consumed by <tt>expr</tt> <br>
+before any action executes. The action can then convert this text or store it.</p>
+<p>The grammar below builds a dictionary from colon-separated pairs:</p>
 <pre>root &lt;- "{" _            { $$ = new(Container) }<br>         pair ("," _ pair)* "}" _ !.<br><br>pair &lt;- key:ident ":" _ val:number { [$$][$key] = $val }<br><br>ident &lt;- $$=[a-zA-Z]+ _<br>number &lt;- digits=[0-9]+ { $$ = evaluate('+' # digits) } _<br>_ &lt;- [ \t\r\n]*<br></pre>
 <p><tt>pair</tt> tags the identifier and number so the action can read <tt>$key</tt> and <br>
 <tt>$val</tt>. <tt>number</tt> captures the digits in <tt>$digits</tt> before converting <br>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -39,28 +39,14 @@
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="compileFunction">compileFunction</a></h2>
 <h3><a name="Syntax">Syntax</a></h3>
-<pre>parser = ppeg.compileFunction(source [, dd [, iref [, rule = 'root']]])<br></pre>
+<pre>'parser' = ppeg.compileFunction(source, [@dd], [@iref], [rule = 'root'])<br></pre>
 <h3><a name="Description">Description</a></h3>
-<table>
-<tr>
-<td>Converts <tt>source</tt> into a parser function and returns it.</td><td><tt>dd</tt> and</td>
-</tr>
-<tr>
-<td colspan=2><tt>iref</tt> are references that become the defaults for the generated</td>
-</tr>
-<tr>
-<td colspan=2>parser. <tt>dd</tt> supplies the starting <tt>$$</tt> value which typically holds the</td>
-</tr>
-<tr>
-<td colspan=2>output dictionary. <tt>iref</tt> receives the character index where parsing</td>
-</tr>
-<tr>
-<td colspan=2>stopped. The optional <tt>rule</tt> argument selects the entry rule and</td>
-</tr>
-<tr>
-<td>defaults to <tt>'root'</tt>.</td><td>&nbsp;</td>
-</tr>
-</table>
+<p>Converts <tt>source</tt> into a parser function and returns it. <tt>dd</tt> and <tt>iref</tt> <br>
+are references that set the default input for the generated parser. <br>
+<tt>dd</tt> supplies the initial <tt>$$</tt> value, often a container for parse <br>
+results but it may be any object. <tt>iref</tt> receives the index where <br>
+parsing stops. The optional <tt>rule</tt> argument selects the entry rule and <br>
+defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
 inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>
@@ -80,22 +66,22 @@ report errors via <tt>ppeg.fail()</tt>.</p>
 <h2><a name="Tags_and_Captures">Tags and Captures</a></h2>
 <table>
 <tr>
-<td colspan=2>Each rule receives and returns <tt>$$</tt>.</td><td colspan=3>Without a tag, called rules work on the</td>
+<td colspan=5>Each rule receives <tt>$$</tt> as both input and output.</td><td>Without a tag, sub-rules</td>
 </tr>
 <tr>
-<td>same container.</td><td colspan=4>Tagging with <tt>name:expr</tt> binds <tt>$$</tt> to <tt>$name</tt> while <tt>expr</tt></td>
+<td colspan=3>operate on the same value.</td><td colspan=3>Tagging with <tt>name:expr</tt> temporarily rebinds <tt>$$</tt></td>
 </tr>
 <tr>
-<td colspan=4>runs and leaves <tt>$name</tt> defined for the rest of the rule.</td><td>If <tt>$$</tt> is a</td>
+<td colspan=4>to <tt>$name</tt> while <tt>expr</tt> runs.</td><td colspan=2>Afterward <tt>$name</tt> holds the result and can be</td>
 </tr>
 <tr>
-<td colspan=3>dictionary, the tag is also stored there automatically.</td><td colspan=2>A capture</td>
+<td colspan=2>used in later actions.</td><td colspan=4>When <tt>$$</tt> is a dictionary the tag is also stored there</td>
 </tr>
 <tr>
-<td colspan=5><tt>name=expr</tt> (or <tt>$$=expr</tt>) records the consumed substring before any actions</td>
+<td>automatically.</td><td colspan=5>A capture <tt>name=expr</tt> (or <tt>$$=expr</tt>) stores the consumed</td>
 </tr>
 <tr>
-<td>run.</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>
+<td colspan=5>substring before any attached actions run.</td><td>&nbsp;</td>
 </tr>
 </table>
 <p>The grammar below builds a dictionary from colon-separated pairs:</p>

--- a/docs/PPEG Documentation.html
+++ b/docs/PPEG Documentation.html
@@ -38,26 +38,23 @@
 <p>Below is a minimal example that compiles <tt>examples/digits.ppeg</tt> into a local parsing function and runs it. The script locates both <tt>ppeg.pika</tt> and <tt>digits.ppeg</tt> relative to its own path so it works no matter which directory it is launched from:</p>
 <pre>include('systools.pika');<br>include('stdlib.pika');<br>include(run.root # '../tools/ppeg/ppeg.pika');<br><br>src = load(run.root # 'digits.ppeg');<br>parseDigits = ppeg.compileFunction(src);<br><br>assert(&gt; parseDigits('12345'));<br>assert(&gt; !parseDigits('12a45'));<br></pre>
 <h2><a name="compileFunction">compileFunction</a></h2>
-<h3><a name="Syntax">Syntax</a></h3>
 <pre>'parser' = ppeg.compileFunction(source)<br></pre>
-<h3><a name="Description">Description</a></h3>
-<p>Converts <tt>source</tt> into a parser function and returns it. <br>
-The returned parser has the following signature:</p>
+<p>Converts <tt>source</tt> into a parser function. The generated parser has the <br>
+following signature:</p>
 <pre>'success' = parser(text, [@dd], [@iref], [rule = 'root'])<br></pre>
-<p><tt>dd</tt> is a reference that supplies the starting <tt>$$</tt> value <br>
-and usually points at a container for the parse results. <br>
-<tt>iref</tt> receives the index where parsing stops. <br>
-The optional <tt>rule</tt> argument selects the entry rule and <br>
+<p><tt>dd</tt> is a reference supplying the starting value of <tt>$$</tt>, normally a <br>
+container to collect results.  <tt>iref</tt> receives the index where parsing <br>
+stopped.  The optional <tt>rule</tt> argument selects the entry rule and <br>
 defaults to <tt>'root'</tt>.</p>
 <h2><a name="PikaScript_Actions">PikaScript Actions</a></h2>
 <p>PPEG grammars may attach PikaScript code to an expression. The code is written <br>
-inside braces <tt>{}</tt> and always succeeds because it ends with <tt>;true</tt>. Before the <br>
-block runs, <tt>$$</tt> already contains the value produced by the expression. The <br>
-action can inspect or modify this value directly.</p>
+ inside braces <tt>{}</tt>. Before the block runs, <tt>$$</tt> already contains the value <br>
+ produced by the expression. The action can inspect or modify this value <br>
+ directly.</p>
 <p>The following helpers are available inside an action:</p>
 
 <ul>
-<li><tt>$$</tt> &#8211; current result container. Use <tt>$$=</tt> before an expression to capture<br>the substring it consumes.
+<li><tt>$$</tt> &#8211; current value passed between rules. Use <tt>name=expr</tt> or <tt>$$=expr</tt><br>to capture the substring an expression consumes.
 <br></li>
 <li><tt>$$s</tt> &#8211; the source string being parsed.<br></li>
 <li><tt>$$i</tt> &#8211; index within <tt>$$s</tt> for the next character.<br></li>

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -64,38 +64,31 @@ launched from:
 compileFunction
 ===============
 
-Syntax
-------
-
     'parser' = ppeg.compileFunction(source)
 
-Description
------------
-
- Converts `source` into a parser function and returns it.
- The returned parser has the following signature:
+ Converts `source` into a parser function. The generated parser has the
+ following signature:
 
      'success' = parser(text, [@dd], [@iref], [rule = 'root'])
 
- `dd` is a reference that supplies the starting `$$` value
- and usually points at a container for the parse results.
- `iref` receives the index where parsing stops.
- The optional `rule` argument selects the entry rule and
+ `dd` is a reference supplying the starting value of `$$`, normally a
+ container to collect results.  `iref` receives the index where parsing
+ stopped.  The optional `rule` argument selects the entry rule and
  defaults to `'root'`.
 
 
 PikaScript Actions
 ==================
 
- PPEG grammars may attach PikaScript code to an expression. The code is written
- inside braces `{}` and always succeeds because it ends with `;true`. Before the
- block runs, `$$` already contains the value produced by the expression. The
- action can inspect or modify this value directly.
+PPEG grammars may attach PikaScript code to an expression. The code is written
+ inside braces `{}`. Before the block runs, `$$` already contains the value
+ produced by the expression. The action can inspect or modify this value
+ directly.
 
  The following helpers are available inside an action:
 
--  `$$` – current result container. Use `$$=` before an expression to capture
-   the substring it consumes.
+-  `$$` – current value passed between rules. Use `name=expr` or `$$=expr`
+   to capture the substring an expression consumes.
 -  `$$s` – the source string being parsed.
 -  `$$i` – index within `$$s` for the next character.
 -  `$$parser` – dictionary holding all generated parser functions.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -72,14 +72,15 @@ Syntax
 Description
 -----------
 
- Converts <code>source</code> into a parser function. If <code>@outFunc</code> is supplied,
- the generated parser is stored there and the call returns <code>true</code>; otherwise it
+ Converts `source` into a parser function. If `@outFunc` is supplied,
+ the generated parser is stored there and the call returns `true`; otherwise it
  returns the new parser.
 
- <code>dd</code> and <code>iref</code> establish the default dictionary container and index
- reference for the parser. They let callers provide an external container and position
- variable that each rule will update. The optional <code>rule</code> parameter selects the
- starting rule and defaults to <code>'root'</code>.
+`dd` and `iref` customize how the generated parser manages state. `dd` is the
+container passed to each rule when no tag rebinding occurs so rules can add to a
+shared dictionary. `iref` is an lvalue that receives the index of the first
+unconsumed character once parsing finishes. The optional `rule` parameter
+selects the entry point and defaults to `'root'`.
 
 
 PikaScript Actions

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -86,23 +86,18 @@ PikaScript Actions
 Tags and Captures
 =================
 
- Every rule receives a single argument in `$$`. Whatever the caller has
- placed there can be read and modified, so `$$` acts as both input and
- output. Unless you tag an expression the exact same object flows into
- each sub-expression and any changes they make remain visible. Tagging
- an expression with `name:expr` temporarily rebinds `$$` to `$name` while
- `expr` runs. When it succeeds `$name` keeps the produced value and `$$`
- reverts to its previous binding. Nothing is automatically merged back
- into the caller&#8217;s `$$`&nbsp;&mdash;&nbsp;store the value yourself if
+ Each rule receives an object in `$$`. If you do not tag any
+ expressions the same value flows through nested expressions and they may
+ modify it directly. A tag `name:expr` binds `$$` to `$name` only while
+ `expr` runs; when it succeeds `$name` keeps the result and `$$` reverts.
+ Nothing is copied back automatically&#8212;store `$name` yourself if
  needed.
 
- Prefixing an expression with `name=` or `$$=` captures the exact text
- that the expression consumes before any actions run.  This is useful for
- converting the substring to another datatype or keeping it for later
- inspection.
+ `name=expr` or `$$=expr` saves the substring consumed by `expr` before
+ actions execute. This is handy for converting digits or preserving the
+ original text.
 
- The following small grammar demonstrates these features by building a
- dictionary from colon separated pairs:
+ The grammar below builds a dictionary from colon separated pairs:
 
      root <- "{" _            { $$ = new(Container) }
               pair ("," _ pair)* "}" _ !.
@@ -113,18 +108,15 @@ Tags and Captures
      number <- digits=[0-9]+ { $$ = evaluate('+' # digits) } _
      _ <- [ \t\r\n]*
 
- Here `pair` tags the identifier and number so its action can access them
- as `$key` and `$val`.  The `number` rule captures the raw digits in
- `$digits` before converting them to a numeric value.  Tagged and
- captured variables remain available until the current rule finishes,
-allowing later actions to read or modify them.
+ `pair` tags the identifier and number so the action can read `$key` and
+ `$val`. `number` captures the digits in `$digits` before converting
+ them. Tagged variables remain available until the rule returns.
 
 Working with Custom Fields
 ==========================
 
- More elaborate grammars often store helper information in `$$` so that
- multiple rules can share it.  The monolithic JSON example distributes
- values into a pre-existing container designated by `$$.target`:
+ Grammars often pass context in `$$`.  The monolithic JSON parser
+ writes results into the container referenced by `$$.target`:
 
      root   <- _ { $$parser.null = coalesce(@$$.null, <null>); }
                 (object / array) !.
@@ -142,6 +134,6 @@ Working with Custom Fields
                 / object
                 / array
 
- The caller initializes `$$.target` to a container and each rule stores
- its result at that location.  Because `target` is just a field inside
- `$$` it is visible to all sub-expressions until the rule returns.
+ Initialize `$$.target` before parsing; each rule stores its result in
+ that field.  Because `target` is just a member of `$$`, all nested
+ rules see it until the current rule finishes.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -67,16 +67,16 @@ compileFunction
 Syntax
 ------
 
-    parser = ppeg.compileFunction(source [, dd [, iref [, rule = 'root']]])
+    'parser' = ppeg.compileFunction(source, [@dd], [@iref], [rule = 'root'])
 
 Description
 -----------
 
- Converts `source` into a parser function and returns it.  `dd` and
- `iref` are references that become the defaults for the generated
- parser. `dd` supplies the starting `$$` value which typically holds the
- output dictionary. `iref` receives the character index where parsing
- stopped. The optional `rule` argument selects the entry rule and
+ Converts `source` into a parser function and returns it. `dd` and `iref`
+ are references that set the default input for the generated parser.
+ `dd` supplies the initial `$$` value, often a container for parse
+ results but it may be any object. `iref` receives the index where
+ parsing stops. The optional `rule` argument selects the entry rule and
  defaults to `'root'`.
 
 
@@ -102,12 +102,12 @@ PikaScript Actions
 Tags and Captures
 =================
 
- Each rule receives and returns `$$`.  Without a tag, called rules work on the
- same container.  Tagging with `name:expr` binds `$$` to `$name` while `expr`
- runs and leaves `$name` defined for the rest of the rule.  If `$$` is a
- dictionary, the tag is also stored there automatically.  A capture
- `name=expr` (or `$$=expr`) records the consumed substring before any actions
- run.
+ Each rule receives `$$` as both input and output.  Without a tag, sub-rules
+ operate on the same value.  Tagging with `name:expr` temporarily rebinds `$$`
+ to `$name` while `expr` runs.  Afterward `$name` holds the result and can be
+ used in later actions.  When `$$` is a dictionary the tag is also stored there
+ automatically.  A capture `name=expr` (or `$$=expr`) stores the consumed
+ substring before any attached actions run.
 
  The grammar below builds a dictionary from colon-separated pairs:
 

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -61,17 +61,26 @@ launched from:
     assert(> parseDigits('12345'));
     assert(> !parseDigits('12a45'));
 
-CompileFunction Arguments
-------------------------
+compileFunction
+===============
 
- `ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule='root']]]])`
- builds a parser from `source`. With `@outFunc` the compiled parser is stored
- there and the call returns `true` on success; otherwise the new parser is
- returned.
+Syntax
+------
 
- `dd` and `iref` become the parser's default `dd` and `iref` parameters so you
- may share a dictionary container and a position reference. `rule` chooses the
- starting rule and defaults to `'root'`.
+    parser = ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule = 'root']]]])
+
+Description
+-----------
+
+ Converts <code>source</code> into a parser function. If <code>@outFunc</code> is supplied,
+ the generated parser is stored there and the call returns <code>true</code>; otherwise it
+ returns the new parser.
+
+ <code>dd</code> and <code>iref</code> establish the default dictionary container and index
+ reference for the parser. They let callers provide an external container and position
+ variable that each rule will update. The optional <code>rule</code> parameter selects the
+ starting rule and defaults to <code>'root'</code>.
+
 
 PikaScript Actions
 ==================

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -61,6 +61,14 @@ launched from:
     assert(> parseDigits('12345'));
     assert(> !parseDigits('12a45'));
 
+CompileFunction Arguments
+------------------------
+
+ `ppeg.compileFunction(src, @outFunc, dd=nil, iref=nil, rule='root')` returns a
+ new parsing function built from `src`. When `@outFunc` is supplied the function
+ is also stored there. The remaining parameters become the defaults for the
+ parser's own arguments, matching the ones used by `ppeg.parse`.
+
 PikaScript Actions
 ==================
 
@@ -83,12 +91,12 @@ PikaScript Actions
 Tags and Captures
 =================
 
- Every rule takes one argument called `$$`. It also serves as the return value.
- When subexpressions are written without tags the same object flows through them
- all and may be modified in place. A tagged expression `name:expr` temporarily
- sets `$$` to `$name` while `expr` runs. After it succeeds `$name` holds the
- result and `$$` reverts to the original object so the rule can decide how to
- use the new value.
+ Every rule takes `$$` as its input and also returns it. Untagged
+ subexpressions therefore share one container and may update it in place. A
+ tagged expression `name:expr` temporarily binds `$$` to `$name` while `expr`
+ runs. When the expression finishes, `$name` contains the produced value and
+ `$$` again refers to the outer container so the rule can decide how to use the
+ new data.
 
  A capture `name=expr` (or `$$=expr`) grabs the substring consumed by `expr`
  before any action executes. The action can then convert this text or store it.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -69,12 +69,12 @@ compileFunction
  Converts `source` into a parser function. The generated parser has the
  following signature:
 
-     'success' = parser(text, [@dd], [@iref], [rule = 'root'])
+    'success' = parser(text, [@result], [@endIndex], [rule = 'root'])
 
- `dd` is a reference supplying the starting value of `$$`, normally a
- container to collect results.  `iref` receives the index where parsing
- stopped.  The optional `rule` argument selects the entry rule and
- defaults to `'root'`.
+ `result` is a reference supplying the starting value of `$$`, normally a
+ container to collect results.  `endIndex` receives the position where
+ parsing stopped.  The optional `rule` argument selects the entry rule
+ and defaults to `'root'`.
 
 
 PikaScript Actions

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -64,40 +64,36 @@ launched from:
 PikaScript Actions
 ==================
 
- PPEG grammars can embed blocks of PikaScript that run when the preceding
- expression succeeds. These action blocks appear inside braces `{}` and end
- with a `;true` so the parser always continues after running the code.
- Before the action executes `$$` already holds the value produced by the
- expression. The code may read or modify this value in place.
+ PPEG grammars may attach PikaScript code to an expression. The code is written
+ inside braces `{}` and always succeeds because it ends with `;true`. Before the
+ block runs, `$$` already contains the value produced by the expression. The
+ action can inspect or modify this value directly.
 
- The following helper variables are available inside an action:
+ The following helpers are available inside an action:
 
 -  `$$` – current result container. Use `$$=` before an expression to capture
-   the raw substring it consumes.
+   the substring it consumes.
 -  `$$s` – the source string being parsed.
--  `$$i` – the index within `$$s` where the next character will be read.
--  `$$parser` – dictionary holding all generated parser functions. Global
-   grammars populate this dictionary while local compilers return it.
+-  `$$i` – index within `$$s` for the next character.
+-  `$$parser` – dictionary holding all generated parser functions.
 
- These identifiers are expanded by the compiler so that actions can inspect
- the input, construct data structures or call helper functions. Use
- `ppeg.fail()` to abort parsing and report an error.
+ These identifiers let actions look at the input, build data structures, or
+ report errors via `ppeg.fail()`.
 
 Tags and Captures
 =================
 
- Each rule receives an object in `$$`. If you do not tag any
- expressions the same value flows through nested expressions and they may
- modify it directly. A tag `name:expr` binds `$$` to `$name` only while
- `expr` runs; when it succeeds `$name` keeps the result and `$$` reverts.
- Nothing is copied back automatically&#8212;store `$name` yourself if
- needed.
+ Every rule takes one argument called `$$`. It also serves as the return value.
+ When subexpressions are written without tags the same object flows through them
+ all and may be modified in place. A tagged expression `name:expr` temporarily
+ sets `$$` to `$name` while `expr` runs. After it succeeds `$name` holds the
+ result and `$$` reverts to the original object so the rule can decide how to
+ use the new value.
 
- `name=expr` or `$$=expr` saves the substring consumed by `expr` before
- actions execute. This is handy for converting digits or preserving the
- original text.
+ A capture `name=expr` (or `$$=expr`) grabs the substring consumed by `expr`
+ before any action executes. The action can then convert this text or store it.
 
- The grammar below builds a dictionary from colon separated pairs:
+ The grammar below builds a dictionary from colon-separated pairs:
 
      root <- "{" _            { $$ = new(Container) }
               pair ("," _ pair)* "}" _ !.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -67,20 +67,17 @@ compileFunction
 Syntax
 ------
 
-    parser = ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule = 'root']]]])
+    parser = ppeg.compileFunction(source [, dd [, iref [, rule = 'root']]])
 
 Description
 -----------
 
- Converts `source` into a parser function. If `@outFunc` is supplied,
- the generated parser is stored there and the call returns `true`; otherwise it
- returns the new parser.
-
-`dd` and `iref` customize how the generated parser manages state. `dd` is the
-container passed to each rule when no tag rebinding occurs so rules can add to a
-shared dictionary. `iref` is an lvalue that receives the index of the first
-unconsumed character once parsing finishes. The optional `rule` parameter
-selects the entry point and defaults to `'root'`.
+ Converts `source` into a parser function and returns it.  `dd` and
+ `iref` are references that become the defaults for the generated
+ parser. `dd` supplies the starting `$$` value which typically holds the
+ output dictionary. `iref` receives the character index where parsing
+ stopped. The optional `rule` argument selects the entry rule and
+ defaults to `'root'`.
 
 
 PikaScript Actions
@@ -105,15 +102,12 @@ PikaScript Actions
 Tags and Captures
 =================
 
- Every rule takes `$$` as its input and also returns it. Untagged
- subexpressions therefore share one container and may update it in place. A
- tagged expression `name:expr` temporarily binds `$$` to `$name` while `expr`
- runs. When the expression finishes, `$name` contains the produced value and
- `$$` again refers to the outer container so the rule can decide how to use the
- new data.
-
- A capture `name=expr` (or `$$=expr`) grabs the substring consumed by `expr`
- before any action executes. The action can then convert this text or store it.
+ Each rule receives and returns `$$`.  Without a tag, called rules work on the
+ same container.  Tagging with `name:expr` binds `$$` to `$name` while `expr`
+ runs and leaves `$name` defined for the rest of the rule.  If `$$` is a
+ dictionary, the tag is also stored there automatically.  A capture
+ `name=expr` (or `$$=expr`) records the consumed substring before any actions
+ run.
 
  The grammar below builds a dictionary from colon-separated pairs:
 
@@ -127,13 +121,13 @@ Tags and Captures
      _ <- [ \t\r\n]*
 
  `pair` tags the identifier and number so the action can read `$key` and
- `$val`. `number` captures the digits in `$digits` before converting
+ `$val`.  `number` captures the digits in `$digits` before converting
  them. Tagged variables remain available until the rule returns.
 
 Working with Custom Fields
 ==========================
 
- Grammars often pass context in `$$`.  The monolithic JSON parser
+ Grammars often store context in a field of `$$`.  The monolithic JSON parser
  writes results into the container referenced by `$$.target`:
 
      root   <- _ { $$parser.null = coalesce(@$$.null, <null>); }
@@ -152,6 +146,5 @@ Working with Custom Fields
                 / object
                 / array
 
- Initialize `$$.target` before parsing; each rule stores its result in
- that field.  Because `target` is just a member of `$$`, all nested
- rules see it until the current rule finishes.
+ Initialize `$$.target` before parsing.  Because `target` is just a member of
+ `$$`, all nested rules see it until the current rule finishes.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -67,16 +67,20 @@ compileFunction
 Syntax
 ------
 
-    'parser' = ppeg.compileFunction(source, [@dd], [@iref], [rule = 'root'])
+    'parser' = ppeg.compileFunction(source)
 
 Description
 -----------
 
- Converts `source` into a parser function and returns it. `dd` and `iref`
- are references that set the default input for the generated parser.
- `dd` supplies the initial `$$` value, often a container for parse
- results but it may be any object. `iref` receives the index where
- parsing stops. The optional `rule` argument selects the entry rule and
+ Converts `source` into a parser function and returns it.
+ The returned parser has the following signature:
+
+     'success' = parser(text, [@dd], [@iref], [rule = 'root'])
+
+ `dd` is a reference that supplies the starting `$$` value
+ and usually points at a container for the parse results.
+ `iref` receives the index where parsing stops.
+ The optional `rule` argument selects the entry rule and
  defaults to `'root'`.
 
 

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -64,10 +64,14 @@ launched from:
 CompileFunction Arguments
 ------------------------
 
- `ppeg.compileFunction(src, @outFunc, dd=nil, iref=nil, rule='root')` returns a
- new parsing function built from `src`. When `@outFunc` is supplied the function
- is also stored there. The remaining parameters become the defaults for the
- parser's own arguments, matching the ones used by `ppeg.parse`.
+ `ppeg.compileFunction(source [, @outFunc [, dd [, iref [, rule='root']]]])`
+ builds a parser from `source`. With `@outFunc` the compiled parser is stored
+ there and the call returns `true` on success; otherwise the new parser is
+ returned.
+
+ `dd` and `iref` become the parser's default `dd` and `iref` parameters so you
+ may share a dictionary container and a position reference. `rule` chooses the
+ starting rule and defaults to `'root'`.
 
 PikaScript Actions
 ==================

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -60,3 +60,88 @@ launched from:
 
     assert(> parseDigits('12345'));
     assert(> !parseDigits('12a45'));
+
+PikaScript Actions
+==================
+
+ PPEG grammars can embed blocks of PikaScript that run when the preceding
+ expression succeeds. These action blocks appear inside braces `{}` and end
+ with a `;true` so the parser always continues after running the code.
+ Before the action executes `$$` already holds the value produced by the
+ expression. The code may read or modify this value in place.
+
+ The following helper variables are available inside an action:
+
+-  `$$` – current result container. Use `$$=` before an expression to capture
+   the raw substring it consumes.
+-  `$$s` – the source string being parsed.
+-  `$$i` – the index within `$$s` where the next character will be read.
+-  `$$parser` – dictionary holding all generated parser functions. Global
+   grammars populate this dictionary while local compilers return it.
+
+ These identifiers are expanded by the compiler so that actions can inspect
+ the input, construct data structures or call helper functions. Use
+ `ppeg.fail()` to abort parsing and report an error.
+
+Tags and Captures
+=================
+
+ Every rule receives a single argument in `$$`. Whatever the caller has
+ placed there can be read and modified, so `$$` acts as both input and
+ output. Unless you tag an expression the exact same object flows into
+ each sub-expression and any changes they make remain visible. Tagging
+ an expression with `name:expr` temporarily rebinds `$$` to `$name` while
+ `expr` runs. When it succeeds `$name` keeps the produced value and `$$`
+ reverts to its previous binding. Nothing is automatically merged back
+ into the caller&#8217;s `$$`&nbsp;&mdash;&nbsp;store the value yourself if
+ needed.
+
+ Prefixing an expression with `name=` or `$$=` captures the exact text
+ that the expression consumes before any actions run.  This is useful for
+ converting the substring to another datatype or keeping it for later
+ inspection.
+
+ The following small grammar demonstrates these features by building a
+ dictionary from colon separated pairs:
+
+     root <- "{" _            { $$ = new(Container) }
+              pair ("," _ pair)* "}" _ !.
+
+     pair <- key:ident ":" _ val:number { [$$][$key] = $val }
+
+     ident <- $$=[a-zA-Z]+ _
+     number <- digits=[0-9]+ { $$ = evaluate('+' # digits) } _
+     _ <- [ \t\r\n]*
+
+ Here `pair` tags the identifier and number so its action can access them
+ as `$key` and `$val`.  The `number` rule captures the raw digits in
+ `$digits` before converting them to a numeric value.  Tagged and
+ captured variables remain available until the current rule finishes,
+allowing later actions to read or modify them.
+
+Working with Custom Fields
+==========================
+
+ More elaborate grammars often store helper information in `$$` so that
+ multiple rules can share it.  The monolithic JSON example distributes
+ values into a pre-existing container designated by `$$.target`:
+
+     root   <- _ { $$parser.null = coalesce(@$$.null, <null>); }
+                (object / array) !.
+
+     object <- "{"_ ( member (","_ member)* )? "}"_
+
+     member <- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }
+                v:value
+
+     value  <- string                     { [$$.target] = $$ }
+                / number                  { [$$.target] = $$ }
+                / "true" _               { [$$.target] = true }
+                / "false" _              { [$$.target] = false }
+                / "null" _               { [$$.target] = $$parser.null }
+                / object
+                / array
+
+ The caller initializes `$$.target` to a container and each rule stores
+ its result at that location.  Because `target` is just a field inside
+ `$$` it is visible to all sub-expressions until the rule returns.

--- a/docs/PPEG Documentation.txt
+++ b/docs/PPEG Documentation.txt
@@ -64,84 +64,52 @@ launched from:
 compileFunction
 ===============
 
-    'parser' = ppeg.compileFunction(source)
+    >parser = ppeg.compileFunction(source)
 
- Converts `source` into a parser function. The generated parser has the
- following signature:
+ Converts `source` into a parser function. The generated parser has the following signature:
 
-    'success' = parser(text, [@result], [@endIndex], [rule = 'root'])
+    ?success = parser(text, [@result], [@endIndex], [rule = 'root'])
 
- `result` is a reference supplying the starting value of `$$`, normally a
- container to collect results.  `endIndex` receives the position where
- parsing stopped.  The optional `rule` argument selects the entry rule
- and defaults to `'root'`.
-
+ `result` is a reference supplying the starting value of `$$`, normally a container to collect results. `endIndex`
+receives the position where parsing stopped. The optional `rule` argument selects the entry rule and defaults to
+`'root'`.
 
 PikaScript Actions
 ==================
 
-PPEG grammars may attach PikaScript code to an expression. The code is written
- inside braces `{}`. Before the block runs, `$$` already contains the value
- produced by the expression. The action can inspect or modify this value
- directly.
+ PPEG grammars may attach PikaScript code to an expression. The code is written inside braces `{}`. Before the block
+runs, `$$` already contains the value produced by the expression. The action can inspect or modify this value
+directly.
 
  The following helpers are available inside an action:
 
--  `$$` – current value passed between rules. Use `name=expr` or `$$=expr`
-   to capture the substring an expression consumes.
--  `$$s` – the source string being parsed.
--  `$$i` – index within `$$s` for the next character.
--  `$$parser` – dictionary holding all generated parser functions.
+- `$$` – current value passed between rules.
+- `$$s` – the source string being parsed.
+- `$$i` – index within `$$s` for the next character.
+- `$$parser` – dictionary holding all generated parser functions.
 
- These identifiers let actions look at the input, build data structures, or
- report errors via `ppeg.fail()`.
+ These identifiers let actions look at the input, build data structures, or report errors via `ppeg.fail()`.
 
 Tags and Captures
 =================
 
- Each rule receives `$$` as both input and output.  Without a tag, sub-rules
- operate on the same value.  Tagging with `name:expr` temporarily rebinds `$$`
- to `$name` while `expr` runs.  Afterward `$name` holds the result and can be
- used in later actions.  When `$$` is a dictionary the tag is also stored there
- automatically.  A capture `name=expr` (or `$$=expr`) stores the consumed
- substring before any attached actions run.
+ Each rule receives `$$` as both input and output. Without a tag, sub-rules operate on the same value. Tagging with
+`name:expr` temporarily rebinds `$$` to `$name` while `expr` runs. Afterward `$name` holds the result and can be used
+in later actions. A capture `name=expr`(or `$$=expr`) stores the consumed substring before any attached actions run.
 
  The grammar below builds a dictionary from colon-separated pairs:
 
-     root <- "{" _            { $$ = new(Container) }
-              pair ("," _ pair)* "}" _ !.
+     root   <-  "{" _                           { $$ = new(Container) }
+                pair ("," _ pair)* "}" _ !.
 
-     pair <- key:ident ":" _ val:number { [$$][$key] = $val }
+     pair   <-  key:ident ":" _ val:number _    { [$$][$key] = $val }
 
-     ident <- $$=[a-zA-Z]+ _
-     number <- digits=[0-9]+ { $$ = evaluate('+' # digits) } _
-     _ <- [ \t\r\n]*
+     ident  <-  $$=[a-zA-Z]+ _
+     number <-  digits=[0-9]+                   { $$ = evaluate('+' # digits) }
+                _
+     
+     _      <-  [ \t\r\n]*
 
- `pair` tags the identifier and number so the action can read `$key` and
- `$val`.  `number` captures the digits in `$digits` before converting
- them. Tagged variables remain available until the rule returns.
+ `pair` tags the identifier and number so the action can read `$key` and `$val`. `number` captures the digits in
+`$digits` before converting them. Tagged variables remain available until the rule returns.
 
-Working with Custom Fields
-==========================
-
- Grammars often store context in a field of `$$`.  The monolithic JSON parser
- writes results into the container referenced by `$$.target`:
-
-     root   <- _ { $$parser.null = coalesce(@$$.null, <null>); }
-                (object / array) !.
-
-     object <- "{"_ ( member (","_ member)* )? "}"_
-
-     member <- id:string ":"_            { $v.target = @[$$.target][undotify($id)] }
-                v:value
-
-     value  <- string                     { [$$.target] = $$ }
-                / number                  { [$$.target] = $$ }
-                / "true" _               { [$$.target] = true }
-                / "false" _              { [$$.target] = false }
-                / "null" _               { [$$.target] = $$parser.null }
-                / object
-                / array
-
- Initialize `$$.target` before parsing.  Because `target` is just a member of
- `$$`, all nested rules see it until the current rule finishes.

--- a/docs/PikaScript History.txt
+++ b/docs/PikaScript History.txt
@@ -21,9 +21,9 @@ standard C++ with no heap allocations and no garbage collection.
 
 The first product to ship with PikaScript was Synplant 1.0, where it controlled GUI interaction with the plugin backend.
 
- In Microtonic 3.0, released in early 2011, PikaScript was exposed to users for the first time. Dropping .pika files into
-a special folder added them to a cog-wheel menu, where they could be launched to automate repetitive tasks like patch
-exports, pattern randomisation, or batch editing. The first official script pack was released in May that year.
+ In Microtonic 3.0, released in early 2011, PikaScript was exposed to users for the first time. Dropping .pika files
+into a special folder added them to a cog-wheel menu, where they could be launched to automate repetitive tasks like
+patch exports, pattern randomisation, or batch editing. The first official script pack was released in May that year.
 
  Newer Sonic Charge plug-ins now use a custom JavaScript engine instead (NuXJS), but PikaScript is still supported for
 legacy scripts and internal tools. The core language has remained unchanged since 2008.

--- a/docs/htmlify Documentation.html
+++ b/docs/htmlify Documentation.html
@@ -35,7 +35,7 @@
 <li>Appending one or more <tt>*</tt> to a word marks a footnote and the text <tt>**</tt> defines it later.</li>
 </ul>
 <p>Any text that does not match a special pattern is HTML escaped to ensure valid output. Source files are assumed to be encoded with UTF-8.</p>
-<p>Headers become&#160;&lt;h1&gt;,&#160;&lt;h2&gt;&#160;or&#160;&lt;h3&gt;&#160;respectively and automatically turn into named anchors that can be referenced simply by writing the exact words again elsewhere.</p>
+<p>Headers become &lt;h1&gt;, &lt;h2&gt; or &lt;h3&gt; respectively and automatically turn into named anchors that can be referenced simply by writing the exact words again elsewhere.</p>
 <h3><a name="Example_Usage">Example Usage</a></h3>
 <p>To convert a document you load <tt>htmlify.pika</tt> and call the <tt>htmlify</tt> function with the text to process. Below is the minimal command used by this project to generate the main documentation:</p>
 <pre>include('tools/htmlify.pika');<br>src = load('docs/PikaScript Documentation.txt');<br>html = htmlify(src);<br>save('docs/PikaScript Documentation.html', html);<br></pre>

--- a/docs/htmlify Documentation.txt
+++ b/docs/htmlify Documentation.txt
@@ -31,7 +31,7 @@ Markup Syntax
  Any text that does not match a special pattern is HTML escaped to ensure valid output. Source files are assumed to be
 encoded with UTF-8.
 
- Headers become <h1>, <h2> or <h3> respectively and automatically turn into named anchors that can be referenced simply
+ Headers become <h1>, <h2> or <h3> respectively and automatically turn into named anchors that can be referenced simply
 by writing the exact words again elsewhere.
 
 
@@ -86,7 +86,8 @@ indentation it will be "unwrapped"
 until...
    The next indented line.
 
-You can write *bold* statements. And _underline_ of course. /Italic/ is written just like that. Enclose text in "grave accents" for teletype, `like this`.
+ You can write *bold* statements. And _underline_ of course. /Italic/ is written just like that. Enclose text in "grave
+accents" for teletype, `like this`.
 
 Urls, like http://www.soniccharge.com automatically turns into href's.
 
@@ -94,7 +95,9 @@ A single line of `==========` (at least 10 of them) creates a horizontal divider
 
 ======================================================================================================================
 
-If you write the exact name of a header in this file it will become a reference. Like this: see Interesting Fruits. But only if this section isn't under the header you reference. So Main Header, First Chapter and Introduction won't become references right now.
+ If you write the exact name of a header in this file it will become a reference. Like this: see Interesting Fruits. But
+only if this section isn't under the header you reference. So Main Header, First Chapter and Introduction won't become
+references right now.
 
 Local images can be inserted like this:
 
@@ -104,9 +107,11 @@ Local images can be inserted like this:
 
 You can also insert remote images like this: [http://www.soniccharge.com/images/flags/SE.png]
 
-Local `.txt` and `.html` files can be referenced by simply writing a filename anywhere like this: test.txt. You can even reference an anchor inside a local html file. For example: test.html#Interesting_Fruits.
+ Local `.txt` and `.html` files can be referenced by simply writing a filename anywhere like this: test.txt. You can
+even reference an anchor inside a local html file. For example: test.html#Interesting_Fruits.
 
-`^` can be used for superscript in mathematical expressions, for example: x^3*5 + x^(7 * y). (Requirement: no space around `^` but at least one space somewhere before next `^`.)
+ `^` can be used for superscript in mathematical expressions, for example: x^3*5 + x^(7 * y). (Requirement: no space
+around `^` but at least one space somewhere before next `^`.)
 
 One or more asterisks after a word creates a reference to a footnote**...
 
@@ -115,7 +120,8 @@ One or more asterisks after a word creates a reference to a footnote**...
 Interesting Fruits
 ------------------
 
-Lists are identified by 1), 2), 3) etc (for ordered lists) and *) or - (for unordered lists). With proper indentation you can create lists beneath other lists.
+ Lists are identified by 1), 2), 3) etc (for ordered lists) and *) or - (for unordered lists). With proper indentation
+you can create lists beneath other lists.
 
 1)  Apple
     Is `good`
@@ -158,7 +164,8 @@ Lists are identified by 1), 2), 3) etc (for ordered lists) and *) or - (for unor
 Examples
 --------
 
-Examples are indented by four or more spaces and they will be put into <pre> </pre> sections. Take a look at the following example:
+ Examples are indented by four or more spaces and they will be put into <pre> </pre> sections. Take a look at the
+following example:
 
     This is an example.
     +-----------------------------+
@@ -172,7 +179,8 @@ But stops here.
 Table Examples
 --------------
 
-Tables are created when a section contains a line with two or more consecutive spaces. These spaces divide the cells horizontally.
+ Tables are created when a section contains a line with two or more consecutive spaces. These spaces divide the cells
+horizontally.
 
 This is a table without headers:
 


### PR DESCRIPTION
## Summary
- clarify semantics for tags and captures in PPEG grammars
- document $$ as input and output with updated explanation
- add example showing use of `$$.target` from JSON parser
- regenerate HTML documentation

## Testing
- `timeout 180 ./build.sh`
- `./output/PikaCmd tools/UpdateHtmlDox.pika`


------
https://chatgpt.com/codex/tasks/task_e_6883d445d2488332ab8179411e708f01