### PR TITLE
Fix doxygen output directory

### DIFF
--- a/docs/PikaScriptDoxyfile
+++ b/docs/PikaScriptDoxyfile
@@ -38,7 +38,7 @@ PROJECT_NUMBER         =
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./
+OUTPUT_DIRECTORY       = docs
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 


### PR DESCRIPTION
## Summary
- generate Doxygen output inside the `docs` folder

## Testing
- `timeout 180 ./build.sh`
- `bash tools/updateDocs.sh`

------
https://chatgpt.com/codex/tasks/task_e_688633e0b90083328ab6e057972cfed0