### PR TITLE
Handle missing doxygen gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tools/PikaCmd/SourceDistribution/PikaCmd
 output/
 /projects/.vs
 /projects/temp/PikaCmd/Debug
+tools/PikaCmd/SourceDistribution/PikaCmd.exe
+tools/PikaCmd/SourceDistribution/PikaCmd.pdb
+tools/PikaCmd/SourceDistribution/vc140.pdb

--- a/tools/updateDocs.cmd
+++ b/tools/updateDocs.cmd
@@ -1,8 +1,13 @@
 CD /D "%~dp0\.."
 output\PikaCmd.exe tools\ExportHelp.pika
 output\PikaCmd.exe tools\UpdateHtmlDox.pika
-doxygen docs\PikaScriptDoxyfile
-CD docs\latex
-pdflatex refman.tex
-CD ..
-move latex\refman.pdf PikaScript.pdf
+where doxygen >nul 2>nul
+IF %ERRORLEVEL% EQU 0 (
+    doxygen docs\PikaScriptDoxyfile
+    CD docs\latex
+    pdflatex refman.tex
+    CD ..
+    move latex\refman.pdf PikaScript.pdf
+) ELSE (
+    echo doxygen not found, skipping PDF build 1>&2
+)

--- a/tools/updateDocs.sh
+++ b/tools/updateDocs.sh
@@ -6,11 +6,10 @@ cd "$(dirname "$0")"/..
 ./output/PikaCmd tools/UpdateHtmlDox.pika
 if command -v doxygen >/dev/null; then
     doxygen docs/PikaScriptDoxyfile
+    cd docs/latex
+    make
+    cd ..
+    cp latex/refman.pdf PikaScript.pdf
 else
-    echo "doxygen is required to build documentation" >&2
-    exit 1
+    echo "doxygen not found; skipping PDF build" >&2
 fi
-cd docs/latex
-make
-cd ..
-cp latex/refman.pdf PikaScript.pdf


### PR DESCRIPTION
## Summary
- update updateDocs scripts to continue when doxygen isn't installed

## Testing
- `timeout 180 ./build.sh`
- `bash tools/updateDocs.sh >/tmp/update.log 2>&1 && sed -n '220,230p' /tmp/update.log`

------
https://chatgpt.com/codex/tasks/task_e_68864131e5d08332b0cd284509862c76