### PR TITLE
Add libFuzzer build script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ bash build.sh
 
 Windows users should run `build.cmd` instead. The script builds the tool in both modes and then runs the full test suite.
 
+## Building the fuzz target
+
+The `tools/build_pikacmd_fuzz.sh` script compiles `tools/PikaCmd/PikaCmd.cpp`
+with libFuzzer and address sanitizer enabled:
+
+```bash
+bash tools/build_pikacmd_fuzz.sh
+```
+
+The resulting binary is placed in `output/PikaCmdFuzz` and can be run with a
+directory containing seed inputs:
+
+```bash
+./output/PikaCmdFuzz corpus/
+```
+
+On macOS the default clang from Xcode does not ship the libFuzzer runtime.
+Install the `llvm` package via Homebrew and invoke the script with that
+compiler:
+
+```bash
+CPP_COMPILER=$(brew --prefix llvm)/bin/clang++ bash tools/build_pikacmd_fuzz.sh
+```
+
 ## License
 
 PikaScript is released under the BSD 2-Clause license. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Windows users should run `build.cmd` instead. The script builds the tool in both
 ## Building the fuzz target
 
 The `tools/build_pikacmd_fuzz.sh` script compiles `tools/PikaCmd/PikaCmd.cpp`
-with libFuzzer and address sanitizer enabled:
+with libFuzzer and address sanitizer enabled. The build forces C++14 because
+`PikaScript` still depends on deprecated functional helpers removed in later
+standards:
 
 ```bash
 bash tools/build_pikacmd_fuzz.sh

--- a/tools/PikaCmd/PikaCmd.cpp
+++ b/tools/PikaCmd/PikaCmd.cpp
@@ -48,6 +48,7 @@
 #include <ctime>
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 #if !defined(PikaScript_h)
 #include "../../src/PikaScript.h"
 #endif

--- a/tools/build_pikacmd_fuzz.cmd
+++ b/tools/build_pikacmd_fuzz.cmd
@@ -1,0 +1,11 @@
+@ECHO OFF
+SETLOCAL
+CD /D "%~dp0\.."
+IF NOT DEFINED CPP_COMPILER SET "CPP_COMPILER=clang++"
+IF NOT EXIST output MKDIR output
+%CPP_COMPILER% -DLIBFUZZ -DPLATFORM_STRING=WINDOWS -fsanitize=fuzzer,address ^
+        -I src tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp ^
+        -o output\PikaCmdFuzz.exe || GOTO error
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/tools/build_pikacmd_fuzz.cmd
+++ b/tools/build_pikacmd_fuzz.cmd
@@ -1,11 +1,11 @@
 @ECHO OFF
 SETLOCAL
 CD /D "%~dp0\.."
-IF NOT DEFINED CPP_COMPILER SET "CPP_COMPILER=clang++"
 IF NOT EXIST output MKDIR output
-%CPP_COMPILER% -DLIBFUZZ -DPLATFORM_STRING=WINDOWS -fsanitize=fuzzer,address ^
-        -I src tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp ^
-        -o output\PikaCmdFuzz.exe || GOTO error
+SET "CPP_OPTIONS=/fsanitize=fuzzer,address"
+CALL tools\PikaCmd\SourceDistribution\BuildCpp.cmd debug x64 output\PikaCmdFuzz.exe ^
+		/D LIBFUZZ /D PLATFORM_STRING=WINDOWS /I src ^
+		tools\PikaCmd\PikaCmd.cpp tools\PikaCmd\BuiltIns.cpp src\PikaScript.cpp src\QStrings.cpp || GOTO error
 EXIT /b 0
 :error
 EXIT /b %ERRORLEVEL%

--- a/tools/build_pikacmd_fuzz.cmd
+++ b/tools/build_pikacmd_fuzz.cmd
@@ -2,7 +2,7 @@
 SETLOCAL
 CD /D "%~dp0\.."
 IF NOT EXIST output MKDIR output
-SET "CPP_OPTIONS=/fsanitize=fuzzer,address"
+SET "CPP_OPTIONS=/std:c++14 /fsanitize=fuzzer,address"
 CALL tools\PikaCmd\SourceDistribution\BuildCpp.cmd debug x64 output\PikaCmdFuzz.exe ^
 		/D LIBFUZZ /D PLATFORM_STRING=WINDOWS /I src ^
 		tools\PikaCmd\PikaCmd.cpp tools\PikaCmd\BuiltIns.cpp src\PikaScript.cpp src\QStrings.cpp || GOTO error

--- a/tools/build_pikacmd_fuzz.sh
+++ b/tools/build_pikacmd_fuzz.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"/..
+
+CPP_COMPILER="${CPP_COMPILER:-clang++}"
+
+mkdir -p output
+
+"$CPP_COMPILER" -DLIBFUZZ -DPLATFORM_STRING=UNIX -fsanitize=fuzzer,address -I src \
+	tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp \
+		-o output/PikaCmdFuzz
+

--- a/tools/build_pikacmd_fuzz.sh
+++ b/tools/build_pikacmd_fuzz.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"/..
 mkdir -p output
 
 CPP_COMPILER="${CPP_COMPILER:-clang++}" \
-CPP_OPTIONS="-fsanitize=fuzzer,address" \
+CPP_OPTIONS="-std=c++14 -fsanitize=fuzzer,address" \
 bash tools/PikaCmd/SourceDistribution/BuildCpp.sh debug native output/PikaCmdFuzz \
 		-DLIBFUZZ -DPLATFORM_STRING=UNIX -I src \
 		tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp

--- a/tools/build_pikacmd_fuzz.sh
+++ b/tools/build_pikacmd_fuzz.sh
@@ -4,9 +4,11 @@ cd "$(dirname "$0")"/..
 
 mkdir -p output
 
-CPP_COMPILER="${CPP_COMPILER:-clang++}" \
-CPP_OPTIONS="-std=c++14 -fsanitize=fuzzer,address" \
+CPP_COMPILER="${CPP_COMPILER:-clang++}"
+CPP_OPTIONS="-std=c++14 -fsanitize=fuzzer,address"
+export CPP_COMPILER CPP_OPTIONS
+
 bash tools/PikaCmd/SourceDistribution/BuildCpp.sh debug native output/PikaCmdFuzz \
-		-DLIBFUZZ -DPLATFORM_STRING=UNIX -I src \
-		tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp
+                -DLIBFUZZ -DPLATFORM_STRING=UNIX -I src \
+                tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp
 

--- a/tools/build_pikacmd_fuzz.sh
+++ b/tools/build_pikacmd_fuzz.sh
@@ -2,11 +2,11 @@
 set -e -o pipefail -u
 cd "$(dirname "$0")"/..
 
-CPP_COMPILER="${CPP_COMPILER:-clang++}"
-
 mkdir -p output
 
-"$CPP_COMPILER" -DLIBFUZZ -DPLATFORM_STRING=UNIX -fsanitize=fuzzer,address -I src \
-	tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp \
-		-o output/PikaCmdFuzz
+CPP_COMPILER="${CPP_COMPILER:-clang++}" \
+CPP_OPTIONS="-fsanitize=fuzzer,address" \
+bash tools/PikaCmd/SourceDistribution/BuildCpp.sh debug native output/PikaCmdFuzz \
+		-DLIBFUZZ -DPLATFORM_STRING=UNIX -I src \
+		tools/PikaCmd/PikaCmd.cpp tools/PikaCmd/BuiltIns.cpp src/PikaScript.cpp src/QStrings.cpp
 


### PR DESCRIPTION
## Summary
- document how to build and run the PikaCmd libFuzzer target
- add cross-platform scripts to build the libFuzzer binary
- include `<cstdint>` so the fuzzer harness compiles

## Testing
- `timeout 180 ./build.sh`
- `bash tools/build_pikacmd_fuzz.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fa33536cc8332b6a85675d7a39f58