### PR TITLE
Bump version references to 0.97

### DIFF
--- a/src/PikaScript.cpp
+++ b/src/PikaScript.cpp
@@ -5,7 +5,7 @@
 	
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	

--- a/src/PikaScript.h
+++ b/src/PikaScript.h
@@ -5,7 +5,7 @@
 	
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -57,10 +57,10 @@ namespace Pika {
 
 #if (PIKA_UNICODE)
 	#define STR(s) L##s
-	#define PIKA_SCRIPT_VERSION L"0.95"
+	#define PIKA_SCRIPT_VERSION L"0.97"
 #else
 	#define STR(x) x
-	#define PIKA_SCRIPT_VERSION "0.95"
+	#define PIKA_SCRIPT_VERSION "0.97"
 #endif
 
 typedef unsigned char uchar;

--- a/src/PikaScriptImpl.h
+++ b/src/PikaScriptImpl.h
@@ -9,7 +9,7 @@
 	                                                                           
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	

--- a/src/QStrings.cpp
+++ b/src/QStrings.cpp
@@ -17,7 +17,7 @@
 
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	

--- a/src/QStrings.h
+++ b/src/QStrings.h
@@ -17,7 +17,7 @@
 
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	

--- a/src/QuickVars.h
+++ b/src/QuickVars.h
@@ -8,7 +8,7 @@
 	
 	\version
 
-	Version 0.95
+	Version 0.97
 		
 	\page Copyright
 

--- a/src/debug.pika
+++ b/src/debug.pika
@@ -1,5 +1,5 @@
 /*
-	debug.pika v0.95
+	debug.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/src/help.pika
+++ b/src/help.pika
@@ -1,5 +1,5 @@
 /*
-	help.pika v0.95
+	help.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/src/interactive.pika
+++ b/src/interactive.pika
@@ -1,7 +1,7 @@
 #! /usr/local/bin/PikaCmd
 
 /*
-	interactive.pika v0.95
+	interactive.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/src/stdlib.pika
+++ b/src/stdlib.pika
@@ -1,5 +1,5 @@
 /*
-	stdlib.pika v0.95
+	stdlib.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/tests/unittests.pika
+++ b/tests/unittests.pika
@@ -1,5 +1,5 @@
 /*
-	unittests.pika v0.95
+	unittests.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/tools/PikaCmd/BuiltIns.cpp
+++ b/tools/PikaCmd/BuiltIns.cpp
@@ -1,6 +1,6 @@
 const char* BUILT_IN_DEBUG =
 	"/*\n"
-	"\tdebug.pika v0.95\n"
+	"\tdebug.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -263,7 +263,7 @@ const char* BUILT_IN_DEBUG =
 
 const char* BUILT_IN_HELP =
 	"/*\n"
-	"\thelp.pika v0.95\n"
+	"\thelp.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -473,7 +473,7 @@ const char* BUILT_IN_INTERACTIVE =
 	"#! /usr/local/bin/PikaCmd\n"
 	"\n"
 	"/*\n"
-	"\tinteractive.pika v0.95\n"
+	"\tinteractive.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -593,7 +593,7 @@ const char* BUILT_IN_INTERACTIVE =
 
 const char* BUILT_IN_STDLIB =
 	"/*\n"
-	"\tstdlib.pika v0.95\n"
+	"\tstdlib.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"

--- a/tools/PikaCmd/PikaCmd.cpp
+++ b/tools/PikaCmd/PikaCmd.cpp
@@ -7,7 +7,7 @@
 
 	\version
 
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 

--- a/tools/PikaCmd/SourceDistribution/PikaCmdAmalgam.cpp
+++ b/tools/PikaCmd/SourceDistribution/PikaCmdAmalgam.cpp
@@ -5,7 +5,7 @@
 	
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -57,10 +57,10 @@ namespace Pika {
 
 #if (PIKA_UNICODE)
 	#define STR(s) L##s
-	#define PIKA_SCRIPT_VERSION L"0.95"
+	#define PIKA_SCRIPT_VERSION L"0.97"
 #else
 	#define STR(x) x
-	#define PIKA_SCRIPT_VERSION "0.95"
+	#define PIKA_SCRIPT_VERSION "0.97"
 #endif
 
 typedef unsigned char uchar;
@@ -597,7 +597,7 @@ typedef Script<StdConfig> StdScript;
 	                                                                           
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -1690,7 +1690,7 @@ TMPL Script<CFG>::Variables::~Variables() { }
 
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -2084,7 +2084,7 @@ bool unitTest();
 	
 	\version
 
-	Version 0.95
+	Version 0.97
 		
 	\page Copyright
 
@@ -2184,7 +2184,7 @@ template<class Super, unsigned int CACHE_SIZE = 11> class QuickVars : public Sup
 	
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -2247,7 +2247,7 @@ template struct Script<StdConfig>;
 
 	\version
 	
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 	
@@ -2339,7 +2339,7 @@ REGISTER_UNIT_TEST(QStrings::unitTest)
 #endif
 const char* BUILT_IN_DEBUG =
 	"/*\n"
-	"\tdebug.pika v0.95\n"
+	"\tdebug.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -2602,7 +2602,7 @@ const char* BUILT_IN_DEBUG =
 
 const char* BUILT_IN_HELP =
 	"/*\n"
-	"\thelp.pika v0.95\n"
+	"\thelp.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -2812,7 +2812,7 @@ const char* BUILT_IN_INTERACTIVE =
 	"#! /usr/local/bin/PikaCmd\n"
 	"\n"
 	"/*\n"
-	"\tinteractive.pika v0.95\n"
+	"\tinteractive.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -2932,7 +2932,7 @@ const char* BUILT_IN_INTERACTIVE =
 
 const char* BUILT_IN_STDLIB =
 	"/*\n"
-	"\tstdlib.pika v0.95\n"
+	"\tstdlib.pika v0.97\n"
 	"\n"
 	"\tPikaScript is released under the \"New Simplified BSD License\". http://www.opensource.org/licenses/bsd-license.php\n"
 	"\t\n"
@@ -3235,7 +3235,7 @@ const char* BUILT_IN_STDLIB =
 
 	\version
 
-	Version 0.95
+	Version 0.97
 	
 	\page Copyright
 
@@ -3276,6 +3276,7 @@ const char* BUILT_IN_STDLIB =
 #include <ctime>
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 #if !defined(PikaScript_h)
 #include "../../src/PikaScript.h"
 #endif

--- a/tools/PikaCmd/SourceDistribution/systools.pika
+++ b/tools/PikaCmd/SourceDistribution/systools.pika
@@ -1,5 +1,5 @@
 /*
-	systools.pika v0.95
+	systools.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/tools/PikaCmd/SourceDistribution/unittests.pika
+++ b/tools/PikaCmd/SourceDistribution/unittests.pika
@@ -1,5 +1,5 @@
 /*
-	unittests.pika v0.95
+	unittests.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	

--- a/tools/PikaCmd/systools.pika
+++ b/tools/PikaCmd/systools.pika
@@ -1,5 +1,5 @@
 /*
-	systools.pika v0.95
+	systools.pika v0.97
 
 	PikaScript is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
 	


### PR DESCRIPTION
## Summary
- update library and tool headers to report version 0.97
- sync standard and debug/interactive scripts to v0.97
- regenerate PikaCmd source distribution and built-ins

## Testing
- `bash tools/PikaCmd/UpdateSourceDistribution.sh`
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c8445e8c08332944ca64d0b7e7455