### PR TITLE
Copy license into source distribution

### DIFF
--- a/tools/PikaCmd/SourceDistribution/LICENSE
+++ b/tools/PikaCmd/SourceDistribution/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2008-2025, NuEdge Development / Magnus Lidstroem
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tools/PikaCmd/UpdateSourceDistribution.cmd
+++ b/tools/PikaCmd/UpdateSourceDistribution.cmd
@@ -22,7 +22,10 @@ IF ERRORLEVEL 1 (
 )
 
 CD SourceDistribution
-COPY /Y ..\..\..\tests\unittests.pika . >NUL && COPY /Y ..\systools.pika . >NUL && COPY /Y ..\..\..\tests\systoolsTests.pika . >NUL
+COPY /Y ..\..\..\tests\unittests.pika . >NUL ^
+		&& COPY /Y ..\systools.pika . >NUL ^
+		&& COPY /Y ..\..\..\tests\systoolsTests.pika . >NUL ^
+		&& COPY /Y ..\..\..\LICENSE . >NUL
 IF ERRORLEVEL 1 (
 	ECHO Failed copying files
 	EXIT /B 1

--- a/tools/PikaCmd/UpdateSourceDistribution.sh
+++ b/tools/PikaCmd/UpdateSourceDistribution.sh
@@ -26,10 +26,13 @@ if [ $? -ne 0 ]; then
 fi
 
 cd SourceDistribution
-cp -f ../../../tests/unittests.pika . && cp -f ../systools.pika . && cp -f ../../../tests/systoolsTests.pika .
+cp -f ../../../tests/unittests.pika . \
+		&& cp -f ../systools.pika . \
+		&& cp -f ../../../tests/systoolsTests.pika . \
+		&& cp -f ../../../LICENSE .
 if [ $? -ne 0 ]; then
-	echo Failed copying files
-	exit 1
+        echo Failed copying files
+        exit 1
 fi
 
 rm -f ./PikaCmd


### PR DESCRIPTION
## Summary
- ensure UpdateSourceDistribution scripts copy the repository LICENSE into the SourceDistribution folder
- include the LICENSE file in tools/PikaCmd/SourceDistribution

## Testing
- `timeout 180 ./build.sh` *(terminated after exceeding time limit during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d405a6ec8332a6103ef4c8d76f7a